### PR TITLE
Support bsc mainnet hardfork at block height 27,281,024

### DIFF
--- a/consensus/parlia/utils.go
+++ b/consensus/parlia/utils.go
@@ -9,7 +9,7 @@ import (
 	"github.com/ledgerwatch/log/v3"
 )
 
-func backOffTime(snap *Snapshot, header *types.Header, val libcommon.Address, chainConfig *chain.Config ) uint64 {
+func backOffTime(snap *Snapshot, header *types.Header, val libcommon.Address, chainConfig *chain.Config) uint64 {
 	if snap.inturn(val) {
 		return 0
 	} else {
@@ -29,17 +29,14 @@ func backOffTime(snap *Snapshot, header *types.Header, val libcommon.Address, ch
 				recentsMap[recent] = seen
 			}
 
-			// if the validator has recently signed, it is unexpected, stop here.
-			if seen, ok := recentsMap[val]; ok {
-				log.Error("unreachable code, validator signed recently",
-					"block", header.Number, "address", val,
-					"seen", seen, "len(snap.Recents)", len(snap.Recents))
+			// The backOffTime does not matter when a validator has signed recently.
+			if _, ok := recentsMap[val]; ok {
 				return 0
 			}
 
 			inTurnAddr := validators[(snap.Number+1)%uint64(len(validators))]
 			if _, ok := recentsMap[inTurnAddr]; ok {
-				log.Info("in turn validator has recently signed, skip initialBackOffTime",
+				log.Debug("in turn validator has recently signed, skip initialBackOffTime",
 					"inTurnAddr", inTurnAddr)
 				delay = 0
 			}

--- a/core/vm/contracts_lightclient.go
+++ b/core/vm/contracts_lightclient.go
@@ -28,6 +28,11 @@ const (
 // 32 bytes               |                 |                   |
 func decodeTendermintHeaderValidationInput(input []byte) (*lightclient.ConsensusState, *lightclient.Header, error) {
 	csLen := binary.BigEndian.Uint64(input[consensusStateLengthBytesLength-uint64TypeLength : consensusStateLengthBytesLength])
+
+	if consensusStateLengthBytesLength+csLen < consensusStateLengthBytesLength {
+		return nil, nil, fmt.Errorf("integer overflow, csLen: %d", csLen)
+	}
+
 	if uint64(len(input)) <= consensusStateLengthBytesLength+csLen {
 		return nil, nil, fmt.Errorf("expected payload size %d, actual size: %d", consensusStateLengthBytesLength+csLen, len(input))
 	}

--- a/params/chainspecs/bsc.json
+++ b/params/chainspecs/bsc.json
@@ -18,7 +18,7 @@
   "nanoBlock": 21962149,
   "moranBlock": 22107423,
   "gibbsBlock": 23846001,
-  "planckBlock": 0,
+  "planckBlock": 27281024,
   "parlia": {
     "DBPath": "",
     "InMemory": false,


### PR DESCRIPTION
Support bsc mainnet hardfork at block height 27,281,024, which will be released in v1.0.2