### PR TITLE
feat: upgrade eth67 handshake msg to be compatible with bsc

### DIFF
--- a/cmd/sentry/sentry/sentry_grpc_server.go
+++ b/cmd/sentry/sentry/sentry_grpc_server.go
@@ -322,6 +322,27 @@ func handShake(
 		}
 	}
 
+	if version >= eth.ETH67 {
+		extensionRaw, err := (&eth.UpgradeStatusExtension{}).Encode()
+		if err != nil {
+			return err
+		}
+		go func() {
+			errc <- p2p.Send(rw, eth.UpgradeStatusMsg, &eth.UpgradeStatusPacket{Extension: extensionRaw})
+		}()
+		//todo: receive UpgradeStatus from bsc and set txBroadcast
+		//		go func() {
+		//			errc <- p.readUpgradeStatus(&upgradeStatus)
+		//		}()
+		select {
+		case err := <-errc:
+			if err != nil {
+				return err
+			}
+		case <-timeout.C:
+			return p2p.DiscReadTimeout
+		}
+	}
 	return nil
 }
 

--- a/eth/protocols/eth/protocol.go
+++ b/eth/protocols/eth/protocol.go
@@ -72,6 +72,9 @@ const (
 	NewPooledTransactionHashesMsg = 0x08
 	GetPooledTransactionsMsg      = 0x09
 	PooledTransactionsMsg         = 0x0a
+
+	//bsc eth67
+	UpgradeStatusMsg = 0x0b
 )
 
 var ToProto = map[uint]map[uint64]proto_sentry.MessageId{
@@ -188,6 +191,23 @@ type StatusPacket struct {
 type NewBlockHashesPacket []struct {
 	Hash   libcommon.Hash // Hash of one particular block being announced
 	Number uint64         // Number of one particular block being announced
+}
+
+// bsc eth67
+type UpgradeStatusPacket struct {
+	Extension *rlp.RawValue `rlp:"nil"`
+}
+type UpgradeStatusExtension struct {
+	DisablePeerTxBroadcast bool
+}
+
+func (e *UpgradeStatusExtension) Encode() (*rlp.RawValue, error) {
+	rawBytes, err := rlp.EncodeToBytes(e)
+	if err != nil {
+		return nil, err
+	}
+	raw := rlp.RawValue(rawBytes)
+	return &raw, nil
 }
 
 // TransactionsPacket is the network packet for broadcasting new transactions.


### PR DESCRIPTION
bsc `eth67` protocol had been changed to be different from `eth`, it has one more round of handshake.