### PR TITLE
consensus: get rid of 1st validator from snap.Recents when check rece…

### DIFF
--- a/consensus/parlia/snapshot.go
+++ b/consensus/parlia/snapshot.go
@@ -377,6 +377,17 @@ func (s *Snapshot) supposeValidator() common.Address {
 	return validators[index]
 }
 
+func (s *Snapshot) signedRecently(validator common.Address) bool {
+	for seen, recent := range s.Recents {
+		if recent == validator {
+			if limit := uint64(len(s.Validators)/2 + 1); s.Number+1 < limit || seen > s.Number+1-limit {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func parseValidators(header *types.Header, chainConfig *chain.Config, parliaConfig *chain.ParliaConfig) ([]libcommon.Address, []types.BLSPublicKey, error) {
 	validatorsBytes := getValidatorBytesFromHeader(header, chainConfig, parliaConfig)
 	if len(validatorsBytes) == 0 {


### PR DESCRIPTION
Update recentSigned logic to consider the first one in snapshot.Recents as no recentSigned.

ref https://github.com/bnb-chain/bsc/pull/1547