### PR TITLE
Optimize the sentry p2p stability

### DIFF
--- a/turbo/stages/headerdownload/header_algos.go
+++ b/turbo/stages/headerdownload/header_algos.go
@@ -438,7 +438,7 @@ func (hd *HeaderDownload) requestMoreHeadersForPOS(currentTime time.Time) (timeo
 		Anchor:  anchor,
 		Hash:    anchor.parentHash,
 		Number:  anchor.blockHeight - 1,
-		Length:  192,
+		Length:  128,
 		Skip:    0,
 		Reverse: true,
 	}
@@ -484,7 +484,7 @@ func (hd *HeaderDownload) RequestSkeleton() *HeaderRequest {
 	log.Debug("[downloader] Request skeleton", "anchors", len(hd.anchors), "highestInDb", hd.highestInDb)
 	var stride uint64
 	if hd.initialCycle {
-		stride = 192
+		stride = 1
 	}
 	var length uint64 = 192
 	// Include one header that we have already, to make sure the responses are not empty and do not get penalised when we are at the tip of the chain


### PR DESCRIPTION
There're frequent logs such as "no block write..", after debugging, find that if strides is too large, some peers are unable to response, so decrease the stride and length to improve the stability of sentry p2p