### PR TITLE
fix: Update the way to get currentValidators

### DIFF
--- a/consensus/parlia/lubanFork.go
+++ b/consensus/parlia/lubanFork.go
@@ -1,8 +1,6 @@
 package parlia
 
 import (
-	"context"
-
 	libcommon "github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon/common/u256"
 	"github.com/ledgerwatch/erigon/core/state"
@@ -27,19 +25,9 @@ func (p *Parlia) getCurrentValidatorsBeforeLuban(header *types.Header, ibs *stat
 		return nil, err
 	}
 
-	ctx := context.Background()
-	// consensus db
-	tx, err := p.db.BeginRo(ctx)
-	if err != nil {
-		return nil, err
-	}
-	defer tx.Rollback()
-	stateReader := state.NewPlainStateReader(tx)
-	ibsForSnapshot := state.New(stateReader)
-
 	// do smart contract call
 	msgData := Bytes(data)
-	_, returnData, err := p.systemCall(header.Coinbase, systemcontracts.ValidatorContract, msgData[:], ibsForSnapshot, header, u256.Num0)
+	_, returnData, err := p.systemCall(header.Coinbase, systemcontracts.ValidatorContract, msgData[:], ibs, header, u256.Num0)
 	if err != nil {
 		return nil, err
 	}

--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -1345,9 +1345,19 @@ func (p *Parlia) getCurrentValidators(header *types.Header, ibs *state.IntraBloc
 		log.Error("Unable to pack tx for getMiningValidators", "err", err)
 		return nil, nil, err
 	}
+
+	ctx := context.Background()
+	// consensus db
+	tx, err := p.db.BeginRo(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer tx.Rollback()
+	stateReader := state.NewPlainStateReader(tx)
+	ibsForSnapshot := state.New(stateReader)
 	// call
 	msgData := hexutility.Bytes(data)
-	_, returnData, err := p.systemCall(header.Coinbase, systemcontracts.ValidatorContract, msgData[:], ibs, header, u256.Num0)
+	_, returnData, err := p.systemCall(header.Coinbase, systemcontracts.ValidatorContract, msgData[:], ibsForSnapshot, header, u256.Num0)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -254,8 +254,6 @@ type Parlia struct {
 	fakeDiff               bool     // Skip difficulty verifications
 	heightForks, timeForks []uint64 // Forks extracted from the chainConfig
 	snapshots              *snapshotsync.RoSnapshots
-	newValidators          []libcommon.Address
-	voteAddressMapmap      map[libcommon.Address]*types.BLSPublicKey
 }
 
 // New creates a Parlia consensus engine.
@@ -857,21 +855,15 @@ func (p *Parlia) Prepare(chain consensus.ChainHeaderReader, header *types.Header
 }
 
 func (p *Parlia) verifyValidators(header, parentHeader *types.Header, state *state.IntraBlockState) error {
-	if (header.Number.Uint64()+1)%p.config.Epoch == 0 {
-		newValidators, voteAddressMap, err := p.getCurrentValidators(header, state)
-		if err != nil {
-			return err
-		}
-		p.newValidators = newValidators
-		p.voteAddressMapmap = voteAddressMap
+	if (header.Number.Uint64())%p.config.Epoch != 0 {
 		return nil
 	}
 
-	if header.Number.Uint64()%p.config.Epoch != 0 {
+	newValidators, voteAddressMap, err := p.getCurrentValidators(parentHeader, state)
+	if err != nil {
 		return nil
 	}
 
-	newValidators, voteAddressMap := p.newValidators, p.voteAddressMapmap
 	// sort validator by address
 	sort.Sort(validatorsAscending(newValidators))
 	var validatorsBytes []byte
@@ -1346,18 +1338,8 @@ func (p *Parlia) getCurrentValidators(header *types.Header, ibs *state.IntraBloc
 		return nil, nil, err
 	}
 
-	ctx := context.Background()
-	// consensus db
-	tx, err := p.db.BeginRo(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	defer tx.Rollback()
-	stateReader := state.NewPlainStateReader(tx)
-	ibsForSnapshot := state.New(stateReader)
-	// call
 	msgData := hexutility.Bytes(data)
-	_, returnData, err := p.systemCall(header.Coinbase, systemcontracts.ValidatorContract, msgData[:], ibsForSnapshot, header, u256.Num0)
+	_, returnData, err := p.systemCall(header.Coinbase, systemcontracts.ValidatorContract, msgData[:], ibs, header, u256.Num0)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
This pr is to solve same issue of https://github.com/node-real/bsc-erigon/pull/54, to make sure getCurrentValidators are always valid even after reboot.
 