### PR TITLE
upgrade: update luban fork height on BSC mainnet

### DIFF
--- a/params/chainspecs/bsc.json
+++ b/params/chainspecs/bsc.json
@@ -19,6 +19,7 @@
     "moranBlock": 22107423,
     "gibbsBlock": 23846001,
     "planckBlock": 27281024,
+    "lubanBlock": 29020050,
     "parlia": {
         "DBPath": "",
         "InMemory": false,


### PR DESCRIPTION
## Description
BSC mainnet hard fork Luban will be enabled on 12th June, detail refer: https://github.com/bnb-chain/bsc/releases/tag/v1.2.4
