### PR TITLE
fix: sync from genesis

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -301,7 +301,7 @@ require (
 replace (
 	github.com/cometbft/cometbft => github.com/bnb-chain/greenfield-tendermint v0.0.0-20230417032003-4cda1f296fb2
 	github.com/grpc-ecosystem/grpc-gateway/v2 => github.com/prysmaticlabs/grpc-gateway/v2 v2.3.1-0.20210702154020-550e1cd83ec1
-	github.com/ledgerwatch/erigon-lib => github.com/node-real/bsc-erigon-lib v1.0.2-0.20230530034327-1ed41d9f05d0
+	github.com/ledgerwatch/erigon-lib => github.com/node-real/bsc-erigon-lib v1.0.2-0.20230601070202-a68e4d50ea74
 	github.com/ledgerwatch/erigon-snapshot => github.com/node-real/bsc-erigon-snapshot v1.0.0
 	github.com/tendermint/tendermint => github.com/bnb-chain/tendermint v0.31.15
 )

--- a/go.sum
+++ b/go.sum
@@ -1235,8 +1235,8 @@ github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OS
 github.com/neelance/astrewrite v0.0.0-20160511093645-99348263ae86/go.mod h1:kHJEU3ofeGjhHklVoIGuVj85JJwZ6kWPaJwCIxgnFmo=
 github.com/neelance/sourcemap v0.0.0-20151028013722-8c68805598ab/go.mod h1:Qr6/a/Q4r9LP1IltGz7tA7iOK1WonHEYhu1HRBA7ZiM=
 github.com/nishanths/predeclared v0.0.0-20200524104333-86fad755b4d3/go.mod h1:nt3d53pc1VYcphSCIaYAJtnPYnr3Zyn8fMq2wvPGPso=
-github.com/node-real/bsc-erigon-lib v1.0.2-0.20230530034327-1ed41d9f05d0 h1:GarrhGaMPGMhLp/Rzk+4pFIsVe8SGTXe7VetwAthwcE=
-github.com/node-real/bsc-erigon-lib v1.0.2-0.20230530034327-1ed41d9f05d0/go.mod h1:fis+CS9DEtVJ6YV/P+CC7Dx27XtiaTf8tsEDy89wcZU=
+github.com/node-real/bsc-erigon-lib v1.0.2-0.20230601070202-a68e4d50ea74 h1:LfNzYcp3WoGKQdE4I85m2uCnzj3cupCfkgprXgd7g+A=
+github.com/node-real/bsc-erigon-lib v1.0.2-0.20230601070202-a68e4d50ea74/go.mod h1:fis+CS9DEtVJ6YV/P+CC7Dx27XtiaTf8tsEDy89wcZU=
 github.com/node-real/bsc-erigon-snapshot v1.0.0 h1:hPHF/EznH3ZrOe60JY6B0kqX2vL75nE9HOelKNNnR18=
 github.com/node-real/bsc-erigon-snapshot v1.0.0/go.mod h1:3AuPxZc85jkehh/HA9h8gabv5MSi3kb/ddtzBsTVJFo=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=


### PR DESCRIPTION
# Description
It fixes issue:[Fail to sync from genesis block](https://github.com/node-real/bsc-erigon/issues/94)
The fix is in another repo: https://github.com/node-real/bsc-erigon-lib/pull/11
Here is the code, will hit `evm.chainRules.IsIstanbul:` at early blocks, need to make IsParlia to use the right precompiles.
```
func (evm *EVM) precompile(addr libcommon.Address) (PrecompiledContract, bool) {
	var precompiles map[libcommon.Address]PrecompiledContract
	switch {
	case evm.chainRules.IsPlato:
		precompiles = PrecompiledContractsPlato
	case evm.chainRules.IsLuban:
		precompiles = PrecompiledContractsLuban
	case evm.chainRules.IsPlanck:
		precompiles = PrecompiledContractsPlanck
	case evm.chainRules.IsMoran:
		precompiles = PrecompiledContractsIsMoran
	case evm.chainRules.IsNano:
		precompiles = PrecompiledContractsNano
	case evm.chainRules.IsBerlin:
		precompiles = PrecompiledContractsBerlin
	case evm.chainRules.IsIstanbul:
		if evm.chainRules.IsParlia {
			precompiles = PrecompiledContractsIstanbulForBSC
		} else {
			precompiles = PrecompiledContractsIstanbul
		}
...
}
```
