### PR TITLE
fix: Update params of request to match erigon request mechanism

### DIFF
--- a/turbo/stages/headerdownload/header_algos.go
+++ b/turbo/stages/headerdownload/header_algos.go
@@ -406,7 +406,7 @@ func (hd *HeaderDownload) RequestMoreHeaders(currentTime time.Time) (*HeaderRequ
 			Number:  anchor.blockHeight - 1,
 			Length:  192,
 			Skip:    0,
-			Reverse: false,
+			Reverse: true,
 		}
 		return false
 	})
@@ -468,7 +468,7 @@ func (hd *HeaderDownload) UpdateStats(req *HeaderRequest, skeleton bool, peer [6
 			}
 		}
 	}
-	//log.Debug("Header request sent", "req", fmt.Sprintf("%+v", req), "peer", fmt.Sprintf("%x", peer)[:8])
+	log.Debug("Header request sent", "req", fmt.Sprintf("%+v", req), "peer", fmt.Sprintf("%x", peer)[:8])
 }
 
 func (hd *HeaderDownload) UpdateRetryTime(req *HeaderRequest, currentTime time.Time, timeout time.Duration) {


### PR DESCRIPTION
According to https://github.com/node-real/bsc-erigon/blob/devel/turbo/stages/headerdownload/header_algos.go#L461-L462
When headerDownloader update its status, it assume the req is in reverse order, so update this reverse bool value.

Should be reverted to older as --drop-useless-peers enabled, shouldn't not if not enable this flag
