### PR TITLE
fix: Solve the mismatch validator bug with final solution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,4 @@ coverage.out
 
 dist
 __debug_bin
+cmd/erigon/Users/

--- a/core/state/intra_block_state.go
+++ b/core/state/intra_block_state.go
@@ -52,7 +52,7 @@ type BalanceIncrease struct {
 // that occur during block's execution.
 // NOT THREAD SAFE!
 type IntraBlockState struct {
-	stateReader StateReader
+	StateReader StateReader
 
 	// This map holds 'live' objects, which will get modified while processing a state transition.
 	stateObjects      map[libcommon.Address]*stateObject
@@ -88,7 +88,7 @@ type IntraBlockState struct {
 // Create a new state from a given trie
 func New(stateReader StateReader) *IntraBlockState {
 	return &IntraBlockState{
-		stateReader:       stateReader,
+		StateReader:       stateReader,
 		stateObjects:      map[libcommon.Address]*stateObject{},
 		stateObjectsDirty: map[libcommon.Address]struct{}{},
 		nilAccounts:       map[libcommon.Address]struct{}{},
@@ -235,7 +235,7 @@ func (sdb *IntraBlockState) GetCodeSize(addr libcommon.Address) int {
 	if stateObject.code != nil {
 		return len(stateObject.code)
 	}
-	l, err := sdb.stateReader.ReadAccountCodeSize(addr, stateObject.data.Incarnation, stateObject.data.CodeHash)
+	l, err := sdb.StateReader.ReadAccountCodeSize(addr, stateObject.data.Incarnation, stateObject.data.CodeHash)
 	if err != nil {
 		sdb.setErrorUnsafe(err)
 	}
@@ -427,7 +427,7 @@ func (sdb *IntraBlockState) getStateObject(addr libcommon.Address) (stateObject 
 		}
 		return nil
 	}
-	account, err := sdb.stateReader.ReadAccountData(addr)
+	account, err := sdb.StateReader.ReadAccountData(addr)
 	if err != nil {
 		sdb.setErrorUnsafe(err)
 		return nil
@@ -503,7 +503,7 @@ func (sdb *IntraBlockState) CreateAccount(addr libcommon.Address, contractCreati
 		if previous != nil && previous.selfdestructed {
 			prevInc = previous.data.Incarnation
 		} else {
-			if inc, err := sdb.stateReader.ReadAccountIncarnation(addr); err == nil {
+			if inc, err := sdb.StateReader.ReadAccountIncarnation(addr); err == nil {
 				prevInc = inc
 			} else {
 				sdb.savedErr = err

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -184,7 +184,7 @@ func (so *stateObject) GetCommittedState(key *libcommon.Hash, out *uint256.Int) 
 		return
 	}
 	// Load from DB in case it is missing.
-	enc, err := so.db.stateReader.ReadAccountStorage(so.address, so.data.GetIncarnation(), key)
+	enc, err := so.db.StateReader.ReadAccountStorage(so.address, so.data.GetIncarnation(), key)
 	if err != nil {
 		so.setError(err)
 		out.Clear()
@@ -328,7 +328,7 @@ func (so *stateObject) Code() []byte {
 	if bytes.Equal(so.CodeHash(), emptyCodeHash) {
 		return nil
 	}
-	code, err := so.db.stateReader.ReadAccountCode(so.Address(), so.data.Incarnation, libcommon.BytesToHash(so.CodeHash()))
+	code, err := so.db.StateReader.ReadAccountCode(so.Address(), so.data.Incarnation, libcommon.BytesToHash(so.CodeHash()))
 	if err != nil {
 		so.setError(fmt.Errorf("can't load code hash %x: %w", so.CodeHash(), err))
 	}


### PR DESCRIPTION
Solve the mismatch validator bug with final solution:
Previously, sometimes "mismatching validator" error occur, after dive into more into the code, the root reason is that ibs(IntraBlockState) is not thread-safe, in evm system contract call, it'll read messy cache data.
With this commit, will create a new state for read validatorList to avoid messy cache data and thread-safe problem