### PR TITLE
release: prepare for release v1.1.6

### DIFF
--- a/params/chainspecs/bsc.json
+++ b/params/chainspecs/bsc.json
@@ -20,6 +20,10 @@
     "gibbsBlock": 23846001,
     "planckBlock": 27281024,
     "lubanBlock": 29020050,
+    "platoBlock": 30720096,
+    "berlinBlock":31302048,
+    "londonBlock": 31302048,
+    "hertzBlock": 31302048,
     "parlia": {
         "DBPath": "",
         "InMemory": false,

--- a/params/version.go
+++ b/params/version.go
@@ -33,7 +33,7 @@ var (
 const (
 	VersionMajor       = 1     // Major version component of the current release
 	VersionMinor       = 1     // Minor version component of the current release
-	VersionMicro       = 5    // Patch version component of the current release
+	VersionMicro       = 6     // Patch version component of the current release
 	VersionModifier    = "dev" // Modifier component of the current release
 	VersionKeyCreated  = "ErigonVersionCreated"
 	VersionKeyFinished = "ErigonVersionFinished"


### PR DESCRIPTION
Follow bsc https://github.com/bnb-chain/bsc/pull/1775
It sets up the hard fork height for both Plato and Hertz(Berlin,London).

Plato: fully enable FastFinality at block height: [30,720,096](https://bscscan.com/block/countdown/30720096), around Aug-10-2023
Hertz: several customized EIPs of Berlin&London on BSC, at block height: [31,302,048](https://bscscan.com/block/countdown/31302048), around Aug-30-2023