### PR TITLE
Increase default --db.size.limit to 10Tb 

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -719,7 +719,7 @@ var (
 	DbSizeLimitFlag = cli.StringFlag{
 		Name:  "db.size.limit",
 		Usage: "runtime limit of chandata db size. you can change value of this flag at any time",
-		Value: (3 * datasize.TB).String(),
+		Value: (10 * datasize.TB).String(),
 	}
 
 	HealthCheckFlag = cli.BoolFlag{


### PR DESCRIPTION
Increase default --db.size.limit to 10Tb 
Fix issue : https://github.com/node-real/bsc-erigon/issues/175