### PR TITLE
Parlia snapshots fix

### DIFF
--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -750,7 +750,7 @@ func (p *Parlia) snapshot(chain consensus.ChainHeaderReader, number uint64, hash
 				}
 			}
 		}
-		if number == 0 || (number%p.config.Epoch == 0 && (len(headers) > params.FullImmutabilityThreshold)) {
+		if number == 0 || (number%p.config.Epoch == 0 && (len(headers) > params.FullImmutabilityThreshold/10)) {
 			// Headers included into the snapshots have to be trusted as checkpoints
 			checkpoint := chain.GetHeader(hash, number)
 			if checkpoint != nil {
@@ -761,8 +761,11 @@ func (p *Parlia) snapshot(chain consensus.ChainHeaderReader, number uint64, hash
 				}
 				// new snapshot
 				snap = newSnapshot(p.config, p.signatures, number, hash, validators, voteAddrs)
-				if err := snap.store(p.db); err != nil {
-					return nil, err
+				if snap.Number%CheckpointInterval == 0 { // snapshot will only be loaded when snap.Number%checkpointInterval == 0
+					if err := snap.store(p.db); err != nil {
+						return nil, err
+					}
+					log.Info("Stored checkpoint snapshot to disk", "number", number, "hash", hash)
 				}
 				break
 			}

--- a/consensus/parlia/snapshot.go
+++ b/consensus/parlia/snapshot.go
@@ -215,6 +215,9 @@ func (s *Snapshot) updateAttestation(header *types.Header, chainConfig *chain.Co
 	}
 
 	// Update attestation
+	// Two scenarios for s.Attestation being nil:
+	// 1) The first attestation is assembled.
+	// 2) The snapshot on disk is missing, prompting the creation of a new snapshot using `newSnapshot`.
 	if s.Attestation != nil && attestation.Data.SourceNumber+1 != attestation.Data.TargetNumber {
 		s.Attestation.TargetNumber = attestation.Data.TargetNumber
 		s.Attestation.TargetHash = attestation.Data.TargetHash


### PR DESCRIPTION
when node crash, the snapshots may lost, then take too much time to found.