### PR TITLE
Fix trace apis after Kepler hard fork.

### DIFF
--- a/cmd/hack/hack.go
+++ b/cmd/hack/hack.go
@@ -215,7 +215,7 @@ func readAccountAtVersion(chaindata string, account string, block uint64) error 
 	}
 	defer tx.Rollback()
 
-	ps := state.NewPlainState(tx, block, nil)
+	ps := state.NewPlainState(tx, block, 0, nil)
 
 	addr := libcommon.HexToAddress(account)
 	acc, err := ps.ReadAccountData(addr)

--- a/cmd/state/commands/check_change_sets.go
+++ b/cmd/state/commands/check_change_sets.go
@@ -142,7 +142,7 @@ func CheckChangeSets(genesis *types.Genesis, logger log.Logger, blockNum uint64,
 		if b == nil {
 			break
 		}
-		reader := state.NewPlainState(historyTx, blockNum, systemcontracts.SystemContractCodeLookup[chainConfig.ChainName])
+		reader := state.NewPlainState(historyTx, b.Time(), blockNum, systemcontracts.SystemContractCodeLookup[chainConfig.ChainName])
 		//reader.SetTrace(blockNum == uint64(block))
 		intraBlockState := state.New(reader)
 		csw := state.NewChangeSetWriterPlain(nil /* db */, blockNum)

--- a/core/state/access_list_test.go
+++ b/core/state/access_list_test.go
@@ -68,7 +68,7 @@ func TestAccessList(t *testing.T) {
 	slot := libcommon.HexToHash
 
 	_, tx := memdb.NewTestTx(t)
-	state := New(NewPlainState(tx, 1, nil))
+	state := New(NewPlainState(tx, 1, 0, nil))
 	state.accessList = newAccessList()
 
 	state.AddAddressToAccessList(addr("aa"))          // 1

--- a/core/state/database_test.go
+++ b/core/state/database_test.go
@@ -839,7 +839,7 @@ func TestReproduceCrash(t *testing.T) {
 
 	_, tx := memdb.NewTestTx(t)
 	tsw := state.NewPlainStateWriter(tx, nil, 1)
-	intraBlockState := state.New(state.NewPlainState(tx, 1, nil))
+	intraBlockState := state.New(state.NewPlainState(tx, 1, 0, nil))
 	// Start the 1st transaction
 	intraBlockState.CreateAccount(contract, true)
 	if err := intraBlockState.FinalizeTx(&chain.Rules{}, tsw); err != nil {
@@ -1262,7 +1262,7 @@ func TestCacheCodeSizeSeparately(t *testing.T) {
 	//root := libcommon.HexToHash("0xb939e5bcf5809adfb87ab07f0795b05b95a1d64a90f0eddd0c3123ac5b433854")
 
 	_, tx := memdb.NewTestTx(t)
-	r, w := state.NewPlainState(tx, 0, nil), state.NewPlainStateWriter(tx, nil, 0)
+	r, w := state.NewPlainState(tx, 0, 0, nil), state.NewPlainStateWriter(tx, nil, 0)
 	intraBlockState := state.New(r)
 	// Start the 1st transaction
 	intraBlockState.CreateAccount(contract, true)
@@ -1295,7 +1295,7 @@ func TestCacheCodeSizeInTrie(t *testing.T) {
 	root := libcommon.HexToHash("0xb939e5bcf5809adfb87ab07f0795b05b95a1d64a90f0eddd0c3123ac5b433854")
 
 	_, tx := memdb.NewTestTx(t)
-	r, w := state.NewPlainState(tx, 0, nil), state.NewPlainStateWriter(tx, nil, 0)
+	r, w := state.NewPlainState(tx, 0, 0, nil), state.NewPlainStateWriter(tx, nil, 0)
 	intraBlockState := state.New(r)
 	// Start the 1st transaction
 	intraBlockState.CreateAccount(contract, true)

--- a/core/state/intra_block_state_test.go
+++ b/core/state/intra_block_state_test.go
@@ -225,7 +225,7 @@ func (test *snapshotTest) run() bool {
 	}
 	defer tx.Rollback()
 	var (
-		ds           = NewPlainState(tx, 1, nil)
+		ds           = NewPlainState(tx, 1, nil, nil)
 		state        = New(ds)
 		snapshotRevs = make([]int, len(test.snapshots))
 		sindex       = 0
@@ -240,7 +240,7 @@ func (test *snapshotTest) run() bool {
 	// Revert all snapshots in reverse order. Each revert must yield a state
 	// that is equivalent to fresh state with all actions up the snapshot applied.
 	for sindex--; sindex >= 0; sindex-- {
-		checkds := NewPlainState(tx, 1, nil)
+		checkds := NewPlainState(tx, 1, nil, nil)
 		checkstate := New(checkds)
 		for _, action := range test.actions[:test.snapshots[sindex]] {
 			action.fn(action, checkstate)

--- a/core/state/plain_readonly.go
+++ b/core/state/plain_readonly.go
@@ -52,12 +52,13 @@ type PlainState struct {
 	accChangesC, storageChangesC kv.CursorDupSort
 	tx                           kv.Tx
 	blockNr                      uint64
+	blockTime                    uint64
 	storage                      map[libcommon.Address]*btree.BTree
 	trace                        bool
 	systemContractLookup         map[libcommon.Address][]libcommon.CodeRecord
 }
 
-func NewPlainState(tx kv.Tx, blockNr uint64, systemContractLookup map[libcommon.Address][]libcommon.CodeRecord) *PlainState {
+func NewPlainState(tx kv.Tx, blockNr uint64, blockTime uint64, systemContractLookup map[libcommon.Address][]libcommon.CodeRecord) *PlainState {
 	histV3, _ := kvcfg.HistoryV3.Enabled(tx)
 	if histV3 {
 		panic("Please use HistoryStateReaderV3 with HistoryV3")
@@ -65,6 +66,7 @@ func NewPlainState(tx kv.Tx, blockNr uint64, systemContractLookup map[libcommon.
 	ps := &PlainState{
 		tx:                   tx,
 		blockNr:              blockNr,
+		blockTime:            blockTime,
 		storage:              make(map[libcommon.Address]*btree.BTree),
 		systemContractLookup: systemContractLookup,
 	}
@@ -188,7 +190,7 @@ func (s *PlainState) ReadAccountData(address libcommon.Address) (*accounts.Accou
 		//restore codehash
 		if records, ok := s.systemContractLookup[address]; ok {
 			p := sort.Search(len(records), func(i int) bool {
-				return records[i].BlockNumber >= s.blockNr
+				return records[i].BlockNumber >= s.blockNr || records[i].BlockTime >= s.blockTime
 			})
 			a.CodeHash = records[p-1].CodeHash
 		} else if a.Incarnation > 0 && a.IsEmptyCodeHash() {

--- a/core/state/state_test.go
+++ b/core/state/state_test.go
@@ -114,8 +114,8 @@ func (s *StateSuite) SetUpTest(c *checker.C) {
 		panic(err)
 	}
 	s.tx = tx
-	s.r = NewPlainState(tx, 1, nil)
-	s.w = NewPlainState(tx, 1, nil)
+	s.r = NewPlainState(tx, 1, 0, nil)
+	s.w = NewPlainState(tx, 1, 0, nil)
 	s.state = New(s.r)
 }
 
@@ -210,8 +210,8 @@ func (s *StateSuite) TestSnapshotEmpty(c *checker.C) {
 // printing/logging in tests (-check.vv does not work)
 func TestSnapshot2(t *testing.T) {
 	_, tx := memdb.NewTestTx(t)
-	w := NewPlainState(tx, 1, nil)
-	state := New(NewPlainState(tx, 1, nil))
+	w := NewPlainState(tx, 1, 0, nil)
+	state := New(NewPlainState(tx, 1, 0, nil))
 
 	stateobjaddr0 := toAddr([]byte("so0"))
 	stateobjaddr1 := toAddr([]byte("so1"))
@@ -236,7 +236,7 @@ func TestSnapshot2(t *testing.T) {
 	if err != nil {
 		t.Fatal("error while finalizing transaction", err)
 	}
-	w = NewPlainState(tx, 2, nil)
+	w = NewPlainState(tx, 2, 0, nil)
 
 	err = state.CommitBlock(&chain.Rules{}, w)
 	if err != nil {

--- a/core/state/temporal/kv_temporal.go
+++ b/core/state/temporal/kv_temporal.go
@@ -57,6 +57,7 @@ func New(db kv.RwDB, agg *state.AggregatorV3, cb1 tConvertV3toV2, cb2 tRestoreCo
 			var err error
 			for _, list := range systemContractLookup {
 				for i := range list {
+					// Need TO DO for timestamp HardFork.
 					list[i].TxNumber, err = rawdbv3.TxNums.Min(tx, list[i].BlockNumber)
 					if err != nil {
 						return err

--- a/core/system_contract_lookup.go
+++ b/core/system_contract_lookup.go
@@ -36,67 +36,73 @@ func init() {
 		if chainConfig.RamanujanBlock != nil {
 			blockNum := chainConfig.RamanujanBlock.Uint64()
 			if blockNum != 0 {
-				addCodeRecords(systemcontracts.RamanujanUpgrade[chainName], blockNum, byChain)
+				addCodeRecords(systemcontracts.RamanujanUpgrade[chainName], blockNum, 0, byChain)
 			}
 		}
 		if chainConfig.NielsBlock != nil {
 			blockNum := chainConfig.NielsBlock.Uint64()
 			if blockNum != 0 {
-				addCodeRecords(systemcontracts.NielsUpgrade[chainName], blockNum, byChain)
+				addCodeRecords(systemcontracts.NielsUpgrade[chainName], blockNum, 0, byChain)
 			}
 		}
 		if chainConfig.MirrorSyncBlock != nil {
 			blockNum := chainConfig.MirrorSyncBlock.Uint64()
 			if blockNum != 0 {
-				addCodeRecords(systemcontracts.MirrorUpgrade[chainName], blockNum, byChain)
+				addCodeRecords(systemcontracts.MirrorUpgrade[chainName], blockNum, 0, byChain)
 			}
 		}
 		if chainConfig.BrunoBlock != nil {
 			blockNum := chainConfig.BrunoBlock.Uint64()
 			if blockNum != 0 {
-				addCodeRecords(systemcontracts.BrunoUpgrade[chainName], blockNum, byChain)
+				addCodeRecords(systemcontracts.BrunoUpgrade[chainName], blockNum, 0, byChain)
 			}
 		}
 		if chainConfig.EulerBlock != nil {
 			blockNum := chainConfig.EulerBlock.Uint64()
 			if blockNum != 0 {
-				addCodeRecords(systemcontracts.EulerUpgrade[chainName], blockNum, byChain)
+				addCodeRecords(systemcontracts.EulerUpgrade[chainName], blockNum, 0, byChain)
 			}
 		}
 		if chainConfig.MoranBlock != nil {
 			blockNum := chainConfig.MoranBlock.Uint64()
 			if blockNum != 0 {
-				addCodeRecords(systemcontracts.MoranUpgrade[chainName], blockNum, byChain)
+				addCodeRecords(systemcontracts.MoranUpgrade[chainName], blockNum, 0, byChain)
 			}
 		}
 		if chainConfig.GibbsBlock != nil {
 			blockNum := chainConfig.GibbsBlock.Uint64()
 			if blockNum != 0 {
-				addCodeRecords(systemcontracts.GibbsUpgrade[chainName], blockNum, byChain)
+				addCodeRecords(systemcontracts.GibbsUpgrade[chainName], blockNum, 0, byChain)
 			}
 		}
 		if chainConfig.PlanckBlock != nil {
 			blockNum := chainConfig.PlanckBlock.Uint64()
 			if blockNum != 0 {
-				addCodeRecords(systemcontracts.PlanckUpgrade[chainName], blockNum, byChain)
+				addCodeRecords(systemcontracts.PlanckUpgrade[chainName], blockNum, 0, byChain)
 			}
 		}
 		if chainConfig.LubanBlock != nil {
 			blockNum := chainConfig.LubanBlock.Uint64()
 			if blockNum != 0 {
-				addCodeRecords(systemcontracts.LubanUpgrade[chainName], blockNum, byChain)
+				addCodeRecords(systemcontracts.LubanUpgrade[chainName], blockNum, 0, byChain)
 			}
 		}
 		if chainConfig.PlatoBlock != nil {
 			blockNum := chainConfig.PlatoBlock.Uint64()
 			if blockNum != 0 {
-				addCodeRecords(systemcontracts.PlatoUpgrade[chainName], blockNum, byChain)
+				addCodeRecords(systemcontracts.PlatoUpgrade[chainName], blockNum, 0, byChain)
+			}
+		}
+		if chainConfig.KeplerTime != nil {
+			blockTime := chainConfig.KeplerTime.Uint64()
+			if blockTime != 0 {
+				addCodeRecords(systemcontracts.KeplerUpgrade[chainName], 0, blockTime, byChain)
 			}
 		}
 		if chainConfig.Bor != nil && chainConfig.Bor.CalcuttaBlock != nil {
 			blockNum := chainConfig.Bor.CalcuttaBlock.Uint64()
 			if blockNum != 0 {
-				addCodeRecords(systemcontracts.CalcuttaUpgrade[chainName], blockNum, byChain)
+				addCodeRecords(systemcontracts.CalcuttaUpgrade[chainName], blockNum, 0, byChain)
 			}
 		}
 	}
@@ -136,7 +142,7 @@ func addGnosisSpecialCase() {
 	byChain[address] = list
 }
 
-func addCodeRecords(upgrade *systemcontracts.Upgrade, blockNum uint64, byChain map[libcommon.Address][]libcommon.CodeRecord) {
+func addCodeRecords(upgrade *systemcontracts.Upgrade, blockNum uint64, blockTime uint64, byChain map[libcommon.Address][]libcommon.CodeRecord) {
 	for _, config := range upgrade.Configs {
 		list := byChain[config.ContractAddr]
 		code, err := hex.DecodeString(config.Code)
@@ -147,7 +153,11 @@ func addCodeRecords(upgrade *systemcontracts.Upgrade, blockNum uint64, byChain m
 		if err != nil {
 			panic(fmt.Errorf("failed to hash system contract code: %s", err.Error()))
 		}
-		list = append(list, libcommon.CodeRecord{BlockNumber: blockNum, CodeHash: codeHash})
+		if blockTime == 0 {
+			list = append(list, libcommon.CodeRecord{BlockNumber: blockNum, CodeHash: codeHash})
+		} else {
+			list = append(list, libcommon.CodeRecord{BlockTime: blockTime, CodeHash: codeHash})
+		}
 		byChain[config.ContractAddr] = list
 	}
 }

--- a/core/vm/runtime/runtime_test.go
+++ b/core/vm/runtime/runtime_test.go
@@ -176,7 +176,7 @@ func BenchmarkCall(b *testing.B) {
 func benchmarkEVM_Create(b *testing.B, code string) {
 	_, tx := memdb.NewTestTx(b)
 	var (
-		statedb  = state.New(state.NewPlainState(tx, 1, nil))
+		statedb  = state.New(state.NewPlainState(tx, 1, 0, nil))
 		sender   = libcommon.BytesToAddress([]byte("sender"))
 		receiver = libcommon.BytesToAddress([]byte("receiver"))
 	)
@@ -342,7 +342,7 @@ func benchmarkNonModifyingCode(b *testing.B, gas uint64, code []byte, name strin
 	cfg := new(Config)
 	setDefaults(cfg)
 	_, tx := memdb.NewTestTx(b)
-	cfg.State = state.New(state.NewPlainState(tx, 1, nil))
+	cfg.State = state.New(state.NewPlainState(tx, 1, 0, nil))
 	cfg.GasLimit = gas
 	var (
 		destination = libcommon.BytesToAddress([]byte("contract"))

--- a/go.mod
+++ b/go.mod
@@ -301,7 +301,7 @@ require (
 replace (
 	github.com/cometbft/cometbft => github.com/bnb-chain/greenfield-tendermint v0.0.0-20230417032003-4cda1f296fb2
 	github.com/grpc-ecosystem/grpc-gateway/v2 => github.com/prysmaticlabs/grpc-gateway/v2 v2.3.1-0.20210702154020-550e1cd83ec1
-	github.com/ledgerwatch/erigon-lib => github.com/node-real/bsc-erigon-lib v1.0.2-0.20231208082640-a478a85b8ef0
+	github.com/ledgerwatch/erigon-lib => github.com/node-real/bsc-erigon-lib v1.0.2-0.20231225072230-73ea392cf3fd
 	github.com/ledgerwatch/erigon-snapshot => github.com/node-real/bsc-erigon-snapshot v1.0.1-0.20231207023556-43c6fd94f10e
 	github.com/tendermint/tendermint => github.com/bnb-chain/tendermint v0.31.15
 )

--- a/go.sum
+++ b/go.sum
@@ -1220,8 +1220,8 @@ github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OS
 github.com/neelance/astrewrite v0.0.0-20160511093645-99348263ae86/go.mod h1:kHJEU3ofeGjhHklVoIGuVj85JJwZ6kWPaJwCIxgnFmo=
 github.com/neelance/sourcemap v0.0.0-20151028013722-8c68805598ab/go.mod h1:Qr6/a/Q4r9LP1IltGz7tA7iOK1WonHEYhu1HRBA7ZiM=
 github.com/nishanths/predeclared v0.0.0-20200524104333-86fad755b4d3/go.mod h1:nt3d53pc1VYcphSCIaYAJtnPYnr3Zyn8fMq2wvPGPso=
-github.com/node-real/bsc-erigon-lib v1.0.2-0.20231208082640-a478a85b8ef0 h1:nTnaoq4cWHDpOv0R2UMZh8OGnnuXsF0KHw5O/Fai6oI=
-github.com/node-real/bsc-erigon-lib v1.0.2-0.20231208082640-a478a85b8ef0/go.mod h1:VfsdM52udAY3ghsNxdJcIVQJDEqE5eVBkFfYQkNHnO4=
+github.com/node-real/bsc-erigon-lib v1.0.2-0.20231225072230-73ea392cf3fd h1:JNUJAvJU821P2GMa0UoQVq2RK/Hjqd1cDxovPzl0S90=
+github.com/node-real/bsc-erigon-lib v1.0.2-0.20231225072230-73ea392cf3fd/go.mod h1:VfsdM52udAY3ghsNxdJcIVQJDEqE5eVBkFfYQkNHnO4=
 github.com/node-real/bsc-erigon-snapshot v1.0.1-0.20231207023556-43c6fd94f10e h1:WSrPOcTazElM5Y/ar2V+HKDzm162XiK61X7tSoYszec=
 github.com/node-real/bsc-erigon-snapshot v1.0.1-0.20231207023556-43c6fd94f10e/go.mod h1:3AuPxZc85jkehh/HA9h8gabv5MSi3kb/ddtzBsTVJFo=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=

--- a/turbo/rpchelper/helper.go
+++ b/turbo/rpchelper/helper.go
@@ -115,7 +115,8 @@ func CreateStateReaderFromBlockNumber(ctx context.Context, tx kv.Tx, blockNumber
 
 func CreateHistoryStateReader(tx kv.Tx, blockNumber uint64, txnIndex int, historyV3 bool, chainName string) (state.StateReader, error) {
 	if !historyV3 {
-		r := state.NewPlainState(tx, blockNumber, systemcontracts.SystemContractCodeLookup[chainName])
+		header := rawdb.ReadHeaderByNumber(tx, blockNumber)
+		r := state.NewPlainState(tx, blockNumber, header.Time, systemcontracts.SystemContractCodeLookup[chainName])
 		//r.SetTrace(true)
 		return r, nil
 	}


### PR DESCRIPTION
Bsc use SystemContractCodeLookup to access code of such contracts instead of query from db. After Kepler hard fork, Bsc hard fork will transfer to blockTime.