### PR TITLE
Fix the bug about trace api.

### DIFF
--- a/core/state/plain_readonly.go
+++ b/core/state/plain_readonly.go
@@ -190,7 +190,7 @@ func (s *PlainState) ReadAccountData(address libcommon.Address) (*accounts.Accou
 		//restore codehash
 		if records, ok := s.systemContractLookup[address]; ok {
 			p := sort.Search(len(records), func(i int) bool {
-				return records[i].BlockNumber >= s.blockNr || records[i].BlockTime >= s.blockTime
+				return records[i].BlockNumber > s.blockNr || records[i].BlockTime > s.blockTime
 			})
 			a.CodeHash = records[p-1].CodeHash
 		} else if a.Incarnation > 0 && a.IsEmptyCodeHash() {


### PR DESCRIPTION
Erigon's history doesn't store "current state" in history. 
It stores prevValue, just State at the beginning of blockNr.
It means history of block N stores "what values we had before block N". 
So, to get value of addr A asOf block N, need find first appearance of A in history of blocks N+1.
![image](https://github.com/node-real/bsc-erigon/assets/125243069/77f2d9fd-63b3-4880-bafc-4f149af990b2)

The bug was introduced by this pr:https://github.com/node-real/bsc-erigon/pull/154.  This pr will revert this change
