### PR TITLE
Incomplete backport for snapshots mechanism

### DIFF
--- a/core/snaptype/block_types.go
+++ b/core/snaptype/block_types.go
@@ -33,6 +33,7 @@ func init() {
 	snapcfg.RegisterKnownTypes(networkname.GoerliChainName, ethereumTypes)
 	snapcfg.RegisterKnownTypes(networkname.GnosisChainName, ethereumTypes)
 	snapcfg.RegisterKnownTypes(networkname.ChiadoChainName, ethereumTypes)
+	snapcfg.RegisterKnownTypes(networkname.BSCChainName, ethereumTypes)
 }
 
 var Enums = struct {


### PR DESCRIPTION
Regarding #395, I suspect the backport of upstream snapshots changes is not complete in recent commits. The snapshots are not correctly detected and updated though hashes are provided. Below is one of the changes that might be left out when backporting.

I will investigate more.