### PR TITLE
getCode: check that state isn't nil

### DIFF
--- a/turbo/jsonrpc/eth_accounts.go
+++ b/turbo/jsonrpc/eth_accounts.go
@@ -91,6 +91,9 @@ func (api *APIImpl) GetCode(ctx context.Context, address libcommon.Address, bloc
 		return nil, err
 	}
 
+	if reader == nil {
+		return nil, fmt.Errorf("getCode cannot open reader for state")
+	}
 	acc, err := reader.ReadAccountData(address)
 	if acc == nil || err != nil {
 		return hexutility.Bytes(""), nil


### PR DESCRIPTION
I was getting errors by repeatedly calling getCode for addresses in blocks where the address doesn't have code. I couldn't check why exactly the reader isn't there. With this patch the errors went away but I'll investigate the issue later.

```
[EROR] [07-06|12:44:06.440] RPC method eth_getCode crashed: runtime error: invalid memory address or nil pointer dereference
[service.go:219 panic.go:914 panic.go:261 signal_unix.go:861 eth_accounts.go:94 value.go:596 value.go:380 service.go:224 handler.go:532 handler.go:482 handler.go:421 handler.go:241 handler.go:334 asm_amd64.s:1650]
[WARN] [07-06|12:44:06.440] [rpc] served                             conn=172.21.0.1:44064 method=eth_getCode reqid=30983592 t=125.085µs err="method handler crashed"
[EROR] [07-06|12:44:06.445] RPC method eth_getCode crashed: runtime error: invalid memory address or nil pointer dereference
[service.go:219 panic.go:914 panic.go:261 signal_unix.go:861 eth_accounts.go:94 value.go:596 value.go:380 service.go:224 handler.go:532 handler.go:482 handler.go:421 handler.go:241 handler.go:334 asm_amd64.s:1650]
[WARN] [07-06|12:44:06.445] [rpc] served                             conn=172.21.0.1:44064 method=eth_getCode reqid=30983599 t=250.813µs err="method handler crashed"
[EROR] [07-06|12:44:06.450] RPC method eth_getCode crashed: runtime error: invalid memory address or nil pointer dereference
[service.go:219 panic.go:914 panic.go:261 signal_unix.go:861 eth_accounts.go:94 value.go:596 value.go:380 service.go:224 handler.go:532 handler.go:482 handler.go:421 handler.go:241 handler.go:334 asm_amd64.s:1650]
[WARN] [07-06|12:44:06.450] [rpc] served                             conn=172.21.0.1:44064 method=eth_getCode reqid=30983606 t=299.094µs err="method handler crashed"
[EROR] [07-06|12:44:06.454] RPC method eth_getCode crashed: runtime error: invalid memory address or nil pointer dereference
[service.go:219 panic.go:914 panic.go:261 signal_unix.go:861 eth_accounts.go:94 value.go:596 value.go:380 service.go:224 handler.go:532 handler.go:482 handler.go:421 handler.go:241 handler.go:334 asm_amd64.s:1650]
[WARN] [07-06|12:44:06.454] [rpc] served                             conn=172.21.0.1:44064 method=eth_getCode reqid=30983613 t=127.62µs err="method handler crashed"
[EROR] [07-06|12:44:06.458] RPC method eth_getCode crashed: runtime error: invalid memory address or nil pointer dereference
[service.go:219 panic.go:914 panic.go:261 signal_unix.go:861 eth_accounts.go:94 value.go:596 value.go:380 service.go:224 handler.go:532 handler.go:482 handler.go:421 handler.go:241 handler.go:334 asm_amd64.s:1650]
[WARN] [07-06|12:44:06.458] [rpc] served                             conn=172.21.0.1:44064 method=eth_getCode reqid=30983620 t=128.903µs err="method handler crashed"
[EROR] [07-06|12:44:06.467] RPC method eth_getCode crashed: runtime error: invalid memory address or nil pointer dereference
[service.go:219 panic.go:914 panic.go:261 signal_unix.go:861 eth_accounts.go:94 value.go:596 value.go:380 service.go:224 handler.go:532 handler.go:482 handler.go:421 handler.go:241 handler.go:334 asm_amd64.s:1650]
```