### PR TITLE
add a mark for latest block

### DIFF
--- a/core/data_availability.go
+++ b/core/data_availability.go
@@ -10,7 +10,7 @@ import (
 )
 
 // IsDataAvailable it checks that the blobTx block has available blob data
-func IsDataAvailable(chain consensus.ChainHeaderReader, header *types.Header, body *types.RawBody) (err error) {
+func IsDataAvailable(chain consensus.ChainHeaderReader, header *types.Header, body *types.RawBody, latest uint64) (err error) {
 	if !chain.Config().IsCancun(header.Number.Uint64(), header.Time) {
 		if body.Sidecars != nil {
 			return errors.New("sidecars present in block body before cancun")
@@ -19,7 +19,7 @@ func IsDataAvailable(chain consensus.ChainHeaderReader, header *types.Header, bo
 	}
 
 	current := chain.CurrentHeader()
-	if header.Number.Uint64()+params.MinBlocksForBlobRequests < current.Number.Uint64() {
+	if header.Number.Uint64()+params.MinBlocksForBlobRequests < max(current.Number.Uint64(), latest) {
 		// if we needn't check DA of this block, just clean it
 		body.CleanSidecars()
 		return nil

--- a/eth/stagedsync/stage_bodies.go
+++ b/eth/stagedsync/stage_bodies.go
@@ -244,7 +244,7 @@ func BodiesForward(
 				metrics.UpdateBlockConsumerBodyDownloadDelay(header.Time, header.Number.Uint64(), logger)
 
 				if cfg.chanConfig.Parlia != nil && cfg.chanConfig.IsCancun(headerNumber, header.Time) {
-					if err = core.IsDataAvailable(cr, header, rawBody); err != nil {
+					if err = core.IsDataAvailable(cr, header, rawBody, cfg.bd.LatestBlock); err != nil {
 						return false, err
 					}
 				}

--- a/p2p/sentry/sentry_multi_client/sentry_multi_client.go
+++ b/p2p/sentry/sentry_multi_client/sentry_multi_client.go
@@ -575,6 +575,9 @@ func (cs *MultiClient) newBlock66(ctx context.Context, inreq *proto_sentry.Inbou
 		return fmt.Errorf("singleHeaderAsSegment failed: %w", err)
 	}
 	cs.Bd.AddToPrefetch(request.Block.Header(), request.Block.RawBody())
+	if cs.Bd.LatestBlock < request.Block.NumberU64() {
+		cs.Bd.LatestBlock = request.Block.NumberU64()
+	}
 	outreq := proto_sentry.PeerMinBlockRequest{
 		PeerId:   inreq.PeerId,
 		MinBlock: request.Block.NumberU64(),

--- a/turbo/stages/bodydownload/body_data_struct.go
+++ b/turbo/stages/bodydownload/body_data_struct.go
@@ -53,6 +53,7 @@ type BodyDownload struct {
 	bodyCacheLimit   int // Limit of body Cache size
 	blockBufferSize  int
 	br               services.FullBlockReader
+	LatestBlock      uint64
 	logger           log.Logger
 }
 


### PR DESCRIPTION
Fix #431 , the problem about blob sidecar miss match
After upstream the latest erigon code. The default check dataAbility logic broken because of `--sync.loop.block.limit`. So add a mark when received new block.