### PR TITLE
Correct ordering of system contract updates

### DIFF
--- a/core/system_contract_lookup.go
+++ b/core/system_contract_lookup.go
@@ -2,9 +2,9 @@ package core
 
 import (
 	"fmt"
+
 	"github.com/ledgerwatch/erigon-lib/chain/networkname"
 	libcommon "github.com/ledgerwatch/erigon-lib/common"
-	"strconv"
 
 	"github.com/ledgerwatch/erigon/core/systemcontracts"
 	"github.com/ledgerwatch/erigon/core/types"
@@ -25,20 +25,21 @@ func init() {
 		if parliaConfig == nil || parliaConfig.BlockAlloc == nil {
 			return
 		}
-		for blockNumOrTime, genesisAlloc := range parliaConfig.BlockAlloc {
-			numOrTime, err := strconv.ParseUint(blockNumOrTime, 10, 64)
-			if err != nil {
-				panic(fmt.Errorf("failed to parse block number in BlockAlloc: %s", err.Error()))
-			}
-			alloc, err := types.DecodeGenesisAlloc(genesisAlloc)
+		blockAlloc, err := parliaConfig.SortedBlockAlloc()
+		if err != nil {
+			panic(fmt.Errorf("failed to sort block alloc: %v", err))
+		}
+
+		for _, pair := range blockAlloc {
+			alloc, err := types.DecodeGenesisAlloc(pair.BlockAlloc)
 			if err != nil {
 				panic(fmt.Errorf("failed to decode block alloc: %v", err))
 			}
 			var blockNum, blockTime uint64
-			if numOrTime >= chainConfig.ShanghaiTime.Uint64() {
-				blockTime = numOrTime
+			if pair.NumOrTime >= chainConfig.ShanghaiTime.Uint64() {
+				blockTime = pair.NumOrTime
 			} else {
-				blockNum = numOrTime
+				blockNum = pair.NumOrTime
 			}
 			allocToCodeRecords(alloc, byChain, blockNum, blockTime)
 		}

--- a/core/systemcontracts/upgrade.go
+++ b/core/systemcontracts/upgrade.go
@@ -2,13 +2,14 @@ package systemcontracts
 
 import (
 	"fmt"
+	"math/big"
+	"strconv"
+
 	"github.com/ledgerwatch/erigon-lib/chain"
 	libcommon "github.com/ledgerwatch/erigon-lib/common"
 	"github.com/ledgerwatch/erigon/core/state"
 	"github.com/ledgerwatch/erigon/core/types"
 	"github.com/ledgerwatch/log/v3"
-	"math/big"
-	"strconv"
 )
 
 type UpgradeConfig struct {

--- a/erigon-lib/chain/chain_config.go
+++ b/erigon-lib/chain/chain_config.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/big"
+	"sort"
 	"strconv"
 
 	"github.com/ledgerwatch/erigon-lib/common"
@@ -708,6 +709,27 @@ type ParliaConfig struct {
 	Period     uint64                 `json:"period"`     // Number of seconds between blocks to enforce
 	Epoch      uint64                 `json:"epoch"`      // Epoch length to update validatorSet
 	BlockAlloc map[string]interface{} `json:"blockAlloc"` // For systemContract upgrade
+}
+
+type KeyValues struct {
+	NumOrTime  uint64
+	BlockAlloc interface{}
+}
+
+func (b *ParliaConfig) SortedBlockAlloc() ([]KeyValues, error) {
+	ret := make([]KeyValues, 0, len(b.BlockAlloc))
+	for blockNumberOrTime, genesisAlloc := range b.BlockAlloc {
+		numOrTime, err := strconv.ParseUint(blockNumberOrTime, 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		ret = append(ret, KeyValues{NumOrTime: numOrTime, BlockAlloc: genesisAlloc})
+	}
+	// sort ret by keys in ascending order
+	sort.Slice(ret, func(i, j int) bool {
+		return ret[i].NumOrTime < ret[j].NumOrTime
+	})
+	return ret, nil
 }
 
 // String implements the stringer interface, returning the consensus engine details.


### PR DESCRIPTION
As we keep sys contract update in map, that's not ordered in go and every time different, we need to sort updates first and apply it correct order 