### PR TITLE
Fix eth_getTransactionReceipts

### DIFF
--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -1269,13 +1269,13 @@ func (p *Parlia) IsSystemTransaction(tx types.Transaction, header *types.Header)
 	if err != nil {
 		return false, errors.New("UnAuthorized transaction")
 	}
-	if sender == header.Coinbase && isToSystemContract(*tx.GetTo()) && tx.GetPrice().IsZero() {
+	if sender == header.Coinbase && IsToSystemContract(*tx.GetTo()) && tx.GetPrice().IsZero() {
 		return true, nil
 	}
 	return false, nil
 }
 
-func isToSystemContract(to libcommon.Address) bool {
+func IsToSystemContract(to libcommon.Address) bool {
 	_, ok := systemContracts[to]
 	return ok
 }
@@ -1284,7 +1284,7 @@ func (p *Parlia) IsSystemContract(to *libcommon.Address) bool {
 	if to == nil {
 		return false
 	}
-	return isToSystemContract(*to)
+	return IsToSystemContract(*to)
 }
 
 func (p *Parlia) EnoughDistance(chain consensus.ChainReader, header *types.Header) bool {

--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -1269,13 +1269,13 @@ func (p *Parlia) IsSystemTransaction(tx types.Transaction, header *types.Header)
 	if err != nil {
 		return false, errors.New("UnAuthorized transaction")
 	}
-	if sender == header.Coinbase && IsToSystemContract(*tx.GetTo()) && tx.GetPrice().IsZero() {
+	if sender == header.Coinbase && isToSystemContract(*tx.GetTo()) && tx.GetPrice().IsZero() {
 		return true, nil
 	}
 	return false, nil
 }
 
-func IsToSystemContract(to libcommon.Address) bool {
+func isToSystemContract(to libcommon.Address) bool {
 	_, ok := systemContracts[to]
 	return ok
 }
@@ -1284,7 +1284,7 @@ func (p *Parlia) IsSystemContract(to *libcommon.Address) bool {
 	if to == nil {
 		return false
 	}
-	return IsToSystemContract(*to)
+	return isToSystemContract(*to)
 }
 
 func (p *Parlia) EnoughDistance(chain consensus.ChainReader, header *types.Header) bool {

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/erigontech/erigon/consensus"
+	"github.com/erigontech/erigon/consensus/parlia"
 	"math"
 	"slices"
 
@@ -335,7 +336,7 @@ func (st *StateTransition) TransitionDb(refunds bool, gasBailout bool) (*evmtype
 	// BSC always gave gas bailout due to system transactions that set 2^256/2 gas limit and
 	// So when trace systemTx, skip PreCheck
 	var skipCheck bool
-	if st.isParlia && st.evm.Config().Debug && st.msg.Gas() == math.MaxUint64/2 {
+	if st.isParlia && st.msg.Gas() == math.MaxUint64/2 && st.gasPrice == uint256.NewInt(0) && parlia.IsToSystemContract(*st.msg.To()) {
 		skipCheck = true
 	}
 

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -229,7 +229,9 @@ func (st *StateTransition) buyGas(gasBailout bool) error {
 	}
 
 	if err := st.gp.SubGas(st.msg.Gas()); err != nil {
-		return err
+		if !gasBailout {
+			return err
+		}
 	}
 	st.gasRemaining += st.msg.Gas()
 	st.initialGas = st.msg.Gas()

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -24,7 +24,6 @@ import (
 	"errors"
 	"fmt"
 	"github.com/erigontech/erigon/consensus"
-	"github.com/erigontech/erigon/consensus/parlia"
 	"math"
 	"slices"
 
@@ -336,7 +335,7 @@ func (st *StateTransition) TransitionDb(refunds bool, gasBailout bool) (*evmtype
 	// BSC always gave gas bailout due to system transactions that set 2^256/2 gas limit and
 	// So when trace systemTx, skip PreCheck
 	var skipCheck bool
-	if st.isParlia && st.msg.Gas() == math.MaxUint64/2 && st.gasPrice == uint256.NewInt(0) && parlia.IsToSystemContract(*st.msg.To()) {
+	if st.isParlia && st.msg.Gas() == math.MaxUint64/2 && st.gasPrice == uint256.NewInt(0) {
 		skipCheck = true
 	}
 

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -337,7 +337,7 @@ func (st *StateTransition) TransitionDb(refunds bool, gasBailout bool) (*evmtype
 	// BSC always gave gas bailout due to system transactions that set 2^256/2 gas limit and
 	// So when trace systemTx, skip PreCheck
 	var skipCheck bool
-	if st.isParlia && st.msg.Gas() == math.MaxUint64/2 && st.gasPrice == uint256.NewInt(0) {
+	if st.isParlia && st.msg.Gas() == math.MaxUint64/2 && st.gasPrice.IsZero() {
 		skipCheck = true
 	}
 


### PR DESCRIPTION
Fix #522 , get system transaction receipt should skip gas check.  In erigon3 need to execute tx to get receipt, so remove st.evm.Config().Debug check, and add gasprice check.