### PR TITLE
Fix trace_* api

### DIFF
--- a/cmd/state/commands/opcode_tracer.go
+++ b/cmd/state/commands/opcode_tracer.go
@@ -723,9 +723,7 @@ func runBlock(engine consensus.Engine, ibs *state.IntraBlockState, txnWriter sta
 	usedGas := new(uint64)
 	usedBlobGas := new(uint64)
 	var receipts types.Receipts
-	// TODO: @blxdyx erigon3 need this?
-	parent := getHeader(header.Hash(), header.Number.Uint64()-1)
-	core.InitializeBlockExecution(engine, nil, header, parent, chainConfig, ibs, logger, nil)
+	core.InitializeBlockExecution(engine, nil, header, chainConfig, ibs, logger, nil)
 	rules := chainConfig.Rules(block.NumberU64(), block.Time())
 	for i, txn := range block.Transactions() {
 		ibs.SetTxContext(i, block.NumberU64())

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -501,6 +501,10 @@ func FinalizeBlockExecution(
 func InitializeBlockExecution(engine consensus.Engine, chain consensus.ChainHeaderReader, header *types.Header,
 	cc *chain.Config, ibs *state.IntraBlockState, logger log.Logger, tracer *tracing.Hooks,
 ) error {
+	// skip this for bsc
+	if cc.Parlia != nil {
+		return nil
+	}
 	engine.Initialize(cc, chain, header, ibs, func(contract libcommon.Address, data []byte, ibState *state.IntraBlockState, header *types.Header, constCall bool) ([]byte, error) {
 		return SysCallContract(contract, data, cc, ibState, header, engine, constCall)
 	}, logger, tracer)

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -506,9 +506,9 @@ func InitializeBlockExecution(engine consensus.Engine, chain consensus.ChainHead
 	engine.Initialize(cc, chain, header, ibs, func(contract libcommon.Address, data []byte, ibState *state.IntraBlockState, header *types.Header, constCall bool) ([]byte, error) {
 		return SysCallContract(contract, data, cc, ibState, header, engine, constCall)
 	}, logger, tracer)
-	if !cc.IsFeynman(header.Number.Uint64(), header.Time) {
-		systemcontracts.UpgradeBuildInSystemContract(cc, header.Number, parent.Time, header.Time, ibs, logger)
-	}
+	//if !cc.IsFeynman(header.Number.Uint64(), header.Time) {
+	//	systemcontracts.UpgradeBuildInSystemContract(cc, header.Number, parent.Time, header.Time, ibs, logger)
+	//}
 
 	noop := state.NewNoopWriter()
 	ibs.FinalizeTx(cc.Rules(header.Number.Uint64(), header.Time), noop)

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -107,8 +107,7 @@ func ExecuteBlockEphemerallyForBSC(
 		receipts    types.Receipts
 	)
 
-	parent := chainReader.GetHeader(header.ParentHash, header.Number.Uint64()-1)
-	if err := InitializeBlockExecution(engine, chainReader, block.Header(), parent, chainConfig, ibs, logger, nil); err != nil {
+	if err := InitializeBlockExecution(engine, chainReader, block.Header(), chainConfig, ibs, logger, nil); err != nil {
 		return nil, err
 	}
 
@@ -246,8 +245,7 @@ func ExecuteBlockEphemerally(
 	gp.AddGas(block.GasLimit()).AddBlobGas(chainConfig.GetMaxBlobGasPerBlock())
 
 	// TODO: send the new tracer once we switch to the tracing.Hook
-	parent := chainReader.GetHeader(header.ParentHash, header.Number.Uint64()-1)
-	if err := InitializeBlockExecution(engine, chainReader, block.Header(), parent, chainConfig, ibs, logger, nil); err != nil {
+	if err := InitializeBlockExecution(engine, chainReader, block.Header(), chainConfig, ibs, logger, nil); err != nil {
 		return nil, err
 	}
 
@@ -500,15 +498,12 @@ func FinalizeBlockExecution(
 	return newBlock, newTxs, newReceipt, nil
 }
 
-func InitializeBlockExecution(engine consensus.Engine, chain consensus.ChainHeaderReader, header, parent *types.Header,
+func InitializeBlockExecution(engine consensus.Engine, chain consensus.ChainHeaderReader, header *types.Header,
 	cc *chain.Config, ibs *state.IntraBlockState, logger log.Logger, tracer *tracing.Hooks,
 ) error {
 	engine.Initialize(cc, chain, header, ibs, func(contract libcommon.Address, data []byte, ibState *state.IntraBlockState, header *types.Header, constCall bool) ([]byte, error) {
 		return SysCallContract(contract, data, cc, ibState, header, engine, constCall)
 	}, logger, tracer)
-	//if !cc.IsFeynman(header.Number.Uint64(), header.Time) {
-	//	systemcontracts.UpgradeBuildInSystemContract(cc, header.Number, parent.Time, header.Time, ibs, logger)
-	//}
 
 	noop := state.NewNoopWriter()
 	ibs.FinalizeTx(cc.Rules(header.Number.Uint64(), header.Time), noop)

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -364,7 +364,7 @@ func GenerateChain(config *chain.Config, parent *types.Block, engine consensus.E
 			}
 		}
 		if b.engine != nil {
-			err := InitializeBlockExecution(b.engine, nil, b.header, b.parent.Header(), config, ibs, logger, nil)
+			err := InitializeBlockExecution(b.engine, nil, b.header, config, ibs, logger, nil)
 			if err != nil {
 				return nil, nil, fmt.Errorf("call to InitializeBlockExecution: %w", err)
 			}

--- a/turbo/jsonrpc/trace_filtering.go
+++ b/turbo/jsonrpc/trace_filtering.go
@@ -769,7 +769,7 @@ func (api *TraceAPIImpl) callManyTransactions(
 	}
 
 	engine := api.engine()
-	consensusHeaderReader := consensuschain.NewReader(cfg, dbtx, nil, nil)
+	consensusHeaderReader := consensuschain.NewReader(cfg, dbtx, api._blockReader, nil)
 	logger := log.New("trace_filtering")
 	parent, err := api._blockReader.HeaderByHash(ctx, dbtx, block.ParentHash())
 	if err != nil {

--- a/turbo/jsonrpc/trace_filtering.go
+++ b/turbo/jsonrpc/trace_filtering.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/erigontech/erigon-lib/log/v3"
+	"github.com/erigontech/erigon/eth/consensuschain"
 
 	"github.com/erigontech/erigon/turbo/shards"
 	jsoniter "github.com/json-iterator/go"
@@ -767,9 +769,9 @@ func (api *TraceAPIImpl) callManyTransactions(
 	}
 
 	engine := api.engine()
-	//consensusHeaderReader := consensuschain.NewReader(cfg, dbtx, api._blockReader, nil)
-	//logger := log.New("trace_filtering")
-	//err = core.InitializeBlockExecution(engine.(consensus.Engine), consensusHeaderReader, block.HeaderNoCopy(), cfg, initialState, logger, nil)
+	consensusHeaderReader := consensuschain.NewReader(cfg, dbtx, api._blockReader, nil)
+	logger := log.New("trace_filtering")
+	err = core.InitializeBlockExecution(engine.(consensus.Engine), consensusHeaderReader, block.HeaderNoCopy(), cfg, initialState, logger, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/turbo/jsonrpc/trace_filtering.go
+++ b/turbo/jsonrpc/trace_filtering.go
@@ -31,7 +31,6 @@ import (
 	"github.com/erigontech/erigon-lib/kv/order"
 	"github.com/erigontech/erigon-lib/kv/rawdbv3"
 	"github.com/erigontech/erigon-lib/kv/stream"
-	"github.com/erigontech/erigon-lib/log/v3"
 	"github.com/erigontech/erigon/consensus"
 	"github.com/erigontech/erigon/consensus/ethash"
 	"github.com/erigontech/erigon/core"
@@ -40,7 +39,6 @@ import (
 	"github.com/erigontech/erigon/core/types"
 	"github.com/erigontech/erigon/core/vm"
 	"github.com/erigontech/erigon/core/vm/evmtypes"
-	"github.com/erigontech/erigon/eth/consensuschain"
 	"github.com/erigontech/erigon/eth/tracers/config"
 	"github.com/erigontech/erigon/ethdb"
 	bortypes "github.com/erigontech/erigon/polygon/bor/types"
@@ -769,13 +767,9 @@ func (api *TraceAPIImpl) callManyTransactions(
 	}
 
 	engine := api.engine()
-	consensusHeaderReader := consensuschain.NewReader(cfg, dbtx, api._blockReader, nil)
-	logger := log.New("trace_filtering")
-	parent, err := api._blockReader.HeaderByHash(ctx, dbtx, block.ParentHash())
-	if err != nil {
-		return nil, nil, err
-	}
-	err = core.InitializeBlockExecution(engine.(consensus.Engine), consensusHeaderReader, block.HeaderNoCopy(), parent, cfg, initialState, logger, nil)
+	//consensusHeaderReader := consensuschain.NewReader(cfg, dbtx, api._blockReader, nil)
+	//logger := log.New("trace_filtering")
+	//err = core.InitializeBlockExecution(engine.(consensus.Engine), consensusHeaderReader, block.HeaderNoCopy(), cfg, initialState, logger, nil)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Fix trace_* api crash.
`[EROR] [10-22|02:55:01.182] RPC method trace_transaction crashed: runtime error: invalid memory address or nil pointer dereference
[service.go:223 panic.go:770 panic.go:261 signal_unix.go:881 parlia.go:913 blockchain.go:506 trace_filtering.go:778 trace_filtering.go:124 value.go:596 value.go:380 service.go:228 handler.go:534 handler.go:484 handler.go:425 handler.go:245 handler.go:338 asm_amd64.s:1695] `