### PR TITLE
experiment: a new sync mode with `DISCARD_COMMITMENT`

### DIFF
--- a/core/genesis_write.go
+++ b/core/genesis_write.go
@@ -26,7 +26,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/erigontech/erigon-lib/common/dbg"
 	"math/big"
 	"slices"
 
@@ -630,11 +629,6 @@ func GenesisToBlock(g *types.Genesis, dirs datadir.Dirs, logger log.Logger) (*ty
 		}
 		if err = statedb.FinalizeTx(&chain.Rules{}, w); err != nil {
 			return err
-		}
-
-		if dbg.DiscardCommitment() {
-			root = *params.GenesisHashByChainName(g.Config.ChainName)
-			return nil
 		}
 
 		rh, err := sd.ComputeCommitment(context.Background(), true, 0, "genesis")

--- a/core/genesis_write.go
+++ b/core/genesis_write.go
@@ -26,6 +26,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/erigontech/erigon-lib/common/dbg"
 	"math/big"
 	"slices"
 
@@ -629,6 +630,11 @@ func GenesisToBlock(g *types.Genesis, dirs datadir.Dirs, logger log.Logger) (*ty
 		}
 		if err = statedb.FinalizeTx(&chain.Rules{}, w); err != nil {
 			return err
+		}
+
+		if dbg.DiscardCommitment() {
+			root = *params.GenesisHashByChainName(g.Config.ChainName)
+			return nil
 		}
 
 		rh, err := sd.ComputeCommitment(context.Background(), true, 0, "genesis")

--- a/core/state/rw_v3.go
+++ b/core/state/rw_v3.go
@@ -194,13 +194,18 @@ func (rs *StateV3) ApplyState4(ctx context.Context, txTask *TxTask) error {
 	}
 
 	if (txTask.TxNum+1)%rs.domains.StepSize() == 0 /*&& txTask.TxNum > 0 */ {
-		// We do not update txNum before commitment cuz otherwise committed state will be in the beginning of next file, not in the latest.
-		// That's why we need to make txnum++ on SeekCommitment to get exact txNum for the latest committed state.
-		//fmt.Printf("[commitment] running due to txNum reached aggregation step %d\n", txNum/rs.domains.StepSize())
-		_, err := rs.domains.ComputeCommitment(ctx, true, txTask.BlockNum,
-			fmt.Sprintf("applying step %d", txTask.TxNum/rs.domains.StepSize()))
-		if err != nil {
-			return fmt.Errorf("StateV3.ComputeCommitment: %w", err)
+		if dbg.DiscardCommitment() {
+			rs.domains.ResetCommitment()
+			_ = rs.domains.SaveCommitment(txTask.BlockNum, txTask.Header.Root.Bytes())
+		} else {
+			// We do not update txNum before commitment cuz otherwise committed state will be in the beginning of next file, not in the latest.
+			// That's why we need to make txnum++ on SeekCommitment to get exact txNum for the latest committed state.
+			//fmt.Printf("[commitment] running due to txNum reached aggregation step %d\n", txNum/rs.domains.StepSize())
+			_, err := rs.domains.ComputeCommitment(ctx, true, txTask.BlockNum,
+				fmt.Sprintf("applying step %d", txTask.TxNum/rs.domains.StepSize()))
+			if err != nil {
+				return fmt.Errorf("StateV3.ComputeCommitment: %w", err)
+			}
 		}
 	}
 

--- a/core/state/rw_v3.go
+++ b/core/state/rw_v3.go
@@ -195,6 +195,7 @@ func (rs *StateV3) ApplyState4(ctx context.Context, txTask *TxTask) error {
 
 	if (txTask.TxNum+1)%rs.domains.StepSize() == 0 /*&& txTask.TxNum > 0 */ {
 		if dbg.DiscardCommitment() {
+			// Don't apply update just save root hash.
 			rs.domains.ResetCommitment()
 			_ = rs.domains.SaveCommitment(txTask.BlockNum, txTask.Header.Root.Bytes())
 		} else {

--- a/erigon-lib/state/aggregator.go
+++ b/erigon-lib/state/aggregator.go
@@ -148,9 +148,6 @@ func NewAggregator(ctx context.Context, dirs datadir.Dirs, aggregationStep uint6
 			if toStep-fromStep > 1 { // only recently built files
 				return true
 			}
-			if dbg.DiscardCommitment() {
-				return true
-			}
 			return commitmentFileMustExist(fromStep, toStep)
 		default:
 			return true

--- a/erigon-lib/state/aggregator.go
+++ b/erigon-lib/state/aggregator.go
@@ -122,7 +122,7 @@ func NewAggregator(ctx context.Context, dirs datadir.Dirs, aggregationStep uint6
 		collateAndBuildWorkers: 1,
 		mergeWorkers:           1,
 
-		commitmentValuesTransform: AggregatorSqueezeCommitmentValues,
+		commitmentValuesTransform: AggregatorSqueezeCommitmentValues && !dbg.DiscardCommitment(),
 
 		produce: true,
 	}
@@ -146,6 +146,9 @@ func NewAggregator(ctx context.Context, dirs datadir.Dirs, aggregationStep uint6
 		switch name {
 		case kv.AccountsDomain, kv.StorageDomain, kv.CodeDomain:
 			if toStep-fromStep > 1 { // only recently built files
+				return true
+			}
+			if dbg.DiscardCommitment() {
 				return true
 			}
 			return commitmentFileMustExist(fromStep, toStep)

--- a/erigon-lib/state/domain_shared.go
+++ b/erigon-lib/state/domain_shared.go
@@ -324,6 +324,12 @@ func (sd *SharedDomains) SeekCommitment(ctx context.Context, tx kv.Tx) (txsFromB
 	if err != nil {
 		return 0, err
 	}
+	if dbg.DiscardCommitment() && bn == 0 {
+		txn = sd.aggTx.EndTxNumNoCommitment()
+		sd.SetBlockNum(bn)
+		sd.SetTxNum(txn)
+		return 0, nil
+	}
 	if ok {
 		if bn > 0 {
 			lastBn, _, err := rawdbv3.TxNums.Last(tx)

--- a/erigon-lib/state/domain_shared.go
+++ b/erigon-lib/state/domain_shared.go
@@ -325,7 +325,7 @@ func (sd *SharedDomains) SeekCommitment(ctx context.Context, tx kv.Tx) (txsFromB
 		return 0, err
 	}
 	if dbg.DiscardCommitment() && bn == 0 {
-		txn = sd.aggTx.EndTxNumNoCommitment()
+		txn = sd.aggTx.EndTxNumNoCommitment() - 1
 		sd.SetBlockNum(bn)
 		sd.SetTxNum(txn)
 		return 0, nil

--- a/erigon-lib/state/domain_shared.go
+++ b/erigon-lib/state/domain_shared.go
@@ -1411,9 +1411,6 @@ func _decodeTxBlockNums(v []byte) (txNum, blockNum uint64) {
 // LatestCommitmentState searches for last encoded state for CommitmentContext.
 // Found value does not become current state.
 func (sdc *SharedDomainsCommitmentContext) LatestCommitmentState() (blockNum, txNum uint64, state []byte, err error) {
-	if dbg.DiscardCommitment() {
-		return 0, 0, nil, nil
-	}
 	if sdc.patriciaTrie.Variant() != commitment.VariantHexPatriciaTrie {
 		return 0, 0, nil, fmt.Errorf("state storing is only supported hex patricia trie")
 	}

--- a/erigon-lib/state/domain_shared.go
+++ b/erigon-lib/state/domain_shared.go
@@ -1135,7 +1135,7 @@ func (sdc *SharedDomainsCommitmentContext) SetLimitReadAsOfTxNum(txNum uint64) {
 func NewSharedDomainsCommitmentContext(sd *SharedDomains, mode commitment.Mode, trieVariant commitment.TrieVariant) *SharedDomainsCommitmentContext {
 	ctx := &SharedDomainsCommitmentContext{
 		sharedDomains: sd,
-		discard:       false,
+		discard:       dbg.DiscardCommitment(),
 		branches:      make(map[string]cachedBranch),
 		keccak:        sha3.NewLegacyKeccak256().(cryptozerocopy.KeccakState),
 	}

--- a/erigon-lib/state/domain_shared.go
+++ b/erigon-lib/state/domain_shared.go
@@ -252,6 +252,10 @@ func (sd *SharedDomains) DiscardWrites(d kv.Domain) {
 	sd.domainWriters[d].h.discard = true
 }
 
+func (sd *SharedDomains) DiscardCommitment() {
+	sd.sdCtx.discard = dbg.DiscardCommitment()
+}
+
 func (sd *SharedDomains) RebuildCommitmentShard(ctx context.Context, next func() (bool, []byte), cfg *RebuiltCommitment) (*RebuiltCommitment, error) {
 	sd.DiscardWrites(kv.AccountsDomain)
 	sd.DiscardWrites(kv.StorageDomain)
@@ -1135,7 +1139,7 @@ func (sdc *SharedDomainsCommitmentContext) SetLimitReadAsOfTxNum(txNum uint64) {
 func NewSharedDomainsCommitmentContext(sd *SharedDomains, mode commitment.Mode, trieVariant commitment.TrieVariant) *SharedDomainsCommitmentContext {
 	ctx := &SharedDomainsCommitmentContext{
 		sharedDomains: sd,
-		discard:       dbg.DiscardCommitment(),
+		discard:       false,
 		branches:      make(map[string]cachedBranch),
 		keccak:        sha3.NewLegacyKeccak256().(cryptozerocopy.KeccakState),
 	}

--- a/eth/stagedsync/exec3.go
+++ b/eth/stagedsync/exec3.go
@@ -201,6 +201,7 @@ func ExecV3(ctx context.Context,
 		defer doms.Close()
 	}
 	txNumInDB := doms.TxNum()
+	doms.DiscardCommitment()
 
 	txNumsReader := rawdbv3.TxNums.WithCustomReadTxNumFunc(freezeblocks.ReadTxNumFuncFromBlockReader(ctx, cfg.blockReader))
 

--- a/eth/stagedsync/exec3.go
+++ b/eth/stagedsync/exec3.go
@@ -795,6 +795,7 @@ Loop:
 					if err != nil {
 						return err
 					}
+					doms.DiscardCommitment()
 					doms.SetTxNum(inputTxNum)
 					rs = state.NewStateV3(doms, logger)
 

--- a/eth/stagedsync/exec3.go
+++ b/eth/stagedsync/exec3.go
@@ -934,11 +934,12 @@ func flushAndCheckCommitmentV3(ctx context.Context, header *types.Header, applyT
 	}
 
 	var rh []byte
+	var err error
 	if dbg.DiscardCommitment() {
 		doms.ResetCommitment()
 		_ = doms.SaveCommitment(doms.BlockNum(), header.Root.Bytes())
 	} else {
-		rh, err := doms.ComputeCommitment(ctx, true, header.Number.Uint64(), e.LogPrefix())
+		rh, err = doms.ComputeCommitment(ctx, true, header.Number.Uint64(), e.LogPrefix())
 		if err != nil {
 			return false, fmt.Errorf("StateV3.Apply: %w", err)
 		}

--- a/eth/stagedsync/exec3.go
+++ b/eth/stagedsync/exec3.go
@@ -687,8 +687,12 @@ Loop:
 			aggTx := applyTx.(state2.HasAggTx).AggTx().(*state2.AggregatorRoTx)
 			aggTx.RestrictSubsetFileDeletions(true)
 			start := time.Now()
-			if _, err := doms.ComputeCommitment(ctx, true, blockNum, execStage.LogPrefix()); err != nil {
-				return err
+			if dbg.DiscardCommitment() {
+				_ = doms.SaveCommitment(blockNum, b.Root().Bytes())
+			} else {
+				if _, err := doms.ComputeCommitment(ctx, true, blockNum, execStage.LogPrefix()); err != nil {
+					return err
+				}
 			}
 			ts += time.Since(start)
 			aggTx.RestrictSubsetFileDeletions(false)
@@ -923,27 +927,30 @@ func flushAndCheckCommitmentV3(ctx context.Context, header *types.Header, applyT
 		return false, errors.New("header is nil")
 	}
 
-	if dbg.DiscardCommitment() {
-		return true, nil
-	}
 	if doms.BlockNum() != header.Number.Uint64() {
 		panic(fmt.Errorf("%d != %d", doms.BlockNum(), header.Number.Uint64()))
 	}
 
-	rh, err := doms.ComputeCommitment(ctx, true, header.Number.Uint64(), e.LogPrefix())
-	if err != nil {
-		return false, fmt.Errorf("StateV3.Apply: %w", err)
+	var rh []byte
+	if dbg.DiscardCommitment() {
+		doms.ResetCommitment()
+		_ = doms.SaveCommitment(doms.BlockNum(), header.Root.Bytes())
+	} else {
+		rh, err := doms.ComputeCommitment(ctx, true, header.Number.Uint64(), e.LogPrefix())
+		if err != nil {
+			return false, fmt.Errorf("StateV3.Apply: %w", err)
+		}
+		if cfg.blockProduction {
+			header.Root = common.BytesToHash(rh)
+			return true, nil
+		}
 	}
-	if cfg.blockProduction {
-		header.Root = common.BytesToHash(rh)
-		return true, nil
-	}
-	if bytes.Equal(rh, header.Root.Bytes()) {
+	if bytes.Equal(rh, header.Root.Bytes()) || dbg.DiscardCommitment() {
 		if !inMemExec {
 			if err := doms.Flush(ctx, applyTx); err != nil {
 				return false, err
 			}
-			if err = applyTx.(state2.HasAggTx).AggTx().(*state2.AggregatorRoTx).PruneCommitHistory(ctx, applyTx, nil); err != nil {
+			if err := applyTx.(state2.HasAggTx).AggTx().(*state2.AggregatorRoTx).PruneCommitHistory(ctx, applyTx, nil); err != nil {
 				return false, err
 			}
 		}

--- a/eth/stagedsync/exec3.go
+++ b/eth/stagedsync/exec3.go
@@ -203,8 +203,6 @@ func ExecV3(ctx context.Context,
 	txNumInDB := doms.TxNum()
 	doms.DiscardCommitment()
 
-	log.Info(fmt.Sprintf("[%s] starting", execStage.LogPrefix()),
-		"from", doms.BlockNum(), "to", maxBlockNum, "fromTxNum", doms.TxNum(), "initialCycle", initialCycle, "useExternalTx", useExternalTx)
 	txNumsReader := rawdbv3.TxNums.WithCustomReadTxNumFunc(freezeblocks.ReadTxNumFuncFromBlockReader(ctx, cfg.blockReader))
 
 	var (

--- a/eth/stagedsync/exec3.go
+++ b/eth/stagedsync/exec3.go
@@ -203,6 +203,8 @@ func ExecV3(ctx context.Context,
 	txNumInDB := doms.TxNum()
 	doms.DiscardCommitment()
 
+	log.Info(fmt.Sprintf("[%s] starting", execStage.LogPrefix()),
+		"from", doms.BlockNum(), "to", maxBlockNum, "fromTxNum", doms.TxNum(), "initialCycle", initialCycle, "useExternalTx", useExternalTx)
 	txNumsReader := rawdbv3.TxNums.WithCustomReadTxNumFunc(freezeblocks.ReadTxNumFuncFromBlockReader(ctx, cfg.blockReader))
 
 	var (


### PR DESCRIPTION
Add a new mode: sync without check state root. It will save disk usage(300gb in bsc) add have higher speed.

How to enable:
1. remove all the commitment 
```
./erigon seg rm-state --domain=commitment --datadir=./data
 rm -rf datadir/chaindata
```
2. restart with env flag ` ERIGON_DISCARD_COMMITMENT=true` 

Attention: If enable this mode can't switch back to the default mode. (Need resync)
 