### PR TITLE
eth_feehistory: fix high latency feehistory

### DIFF
--- a/eth/gasprice/feehistory.go
+++ b/eth/gasprice/feehistory.go
@@ -297,7 +297,7 @@ func (oracle *Oracle) FeeHistory(ctx context.Context, blocks int, unresolvedLast
 			if len(rewardPercentiles) != 0 {
 				fees.block, fees.err = oracle.backend.BlockByNumber(ctx, rpc.BlockNumber(blockNumber))
 				if fees.block != nil && fees.err == nil {
-					fees.receipts, fees.err = oracle.backend.GetReceipts(ctx, fees.block)
+					fees.receipts, fees.err = oracle.backend.GetReceiptsGasUsed(fees.block)
 				}
 			} else {
 				fees.header, fees.err = oracle.backend.HeaderByNumber(ctx, rpc.BlockNumber(blockNumber))

--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -46,6 +46,7 @@ type OracleBackend interface {
 
 	GetReceipts(ctx context.Context, block *types.Block) (types.Receipts, error)
 	PendingBlockAndReceipts() (*types.Block, types.Receipts)
+	GetReceiptsGasUsed(block *types.Block) (types.Receipts, error)
 }
 
 type Cache interface {

--- a/turbo/jsonrpc/eth_receipts.go
+++ b/turbo/jsonrpc/eth_receipts.go
@@ -56,6 +56,10 @@ func (api *BaseAPI) getReceipt(ctx context.Context, cc *chain.Config, tx kv.Temp
 	return api.receiptsGenerator.GetReceipt(ctx, cc, tx, header, txn, index, txNum)
 }
 
+func (api *BaseAPI) getReceiptsGasUsed(tx kv.TemporalTx, block *types.Block) (types.Receipts, error) {
+	return api.receiptsGenerator.GetReceiptsGasUsed(tx, block)
+}
+
 func (api *BaseAPI) getCachedReceipt(ctx context.Context, hash common.Hash) (*types.Receipt, bool) {
 	return api.receiptsGenerator.GetCachedReceipt(ctx, hash)
 }

--- a/turbo/jsonrpc/eth_system.go
+++ b/turbo/jsonrpc/eth_system.go
@@ -329,3 +329,6 @@ func (b *GasPriceOracleBackend) GetReceipts(ctx context.Context, block *types.Bl
 func (b *GasPriceOracleBackend) PendingBlockAndReceipts() (*types.Block, types.Receipts) {
 	return nil, nil
 }
+func (b *GasPriceOracleBackend) GetReceiptsGasUsed(block *types.Block) (types.Receipts, error) {
+	return b.baseApi.getReceiptsGasUsed(b.tx, block)
+}

--- a/turbo/jsonrpc/receipts/receipts_generator.go
+++ b/turbo/jsonrpc/receipts/receipts_generator.go
@@ -198,14 +198,12 @@ func (g *Generator) GetReceiptsGasUsed(tx kv.TemporalTx, block *types.Block) (ty
 		return nil, fmt.Errorf("get min tx num: %w", err)
 	}
 
-	txCount := len(block.Transactions())
-	receipts := make(types.Receipts, txCount)
+	receipts := make(types.Receipts, len(block.Transactions()))
 
 	var prevCumGasUsed uint64
-	currentTxNum := startTxNum + 1
-	for i := 0; i < txCount; i++ {
+	currentTxNum := startTxNum + 2
+	for i := range block.Transactions() {
 		receipt := &types.Receipt{}
-
 		cumGasUsed, _, _, err := rawtemporaldb.ReceiptAsOf(tx, currentTxNum)
 		if err != nil {
 			return nil, fmt.Errorf("get receipt for tx %d: %w", currentTxNum, err)

--- a/turbo/jsonrpc/receipts/receipts_generator.go
+++ b/turbo/jsonrpc/receipts/receipts_generator.go
@@ -201,12 +201,12 @@ func (g *Generator) GetReceiptsGasUsed(tx kv.TemporalTx, block *types.Block) (ty
 	txCount := len(block.Transactions())
 	receipts := make(types.Receipts, txCount)
 
-	prevCumGasUsed, _, _, err := rawtemporaldb.ReceiptAsOf(tx, startTxNum-1)
+	prevCumGasUsed, _, _, err := rawtemporaldb.ReceiptAsOf(tx, startTxNum-2)
 	if err != nil {
 		return nil, fmt.Errorf("get base receipt: %w", err)
 	}
 
-	currentTxNum := startTxNum
+	currentTxNum := startTxNum + 1
 	for i := 0; i < txCount; i++ {
 		receipt := &types.Receipt{}
 

--- a/turbo/jsonrpc/receipts/receipts_generator.go
+++ b/turbo/jsonrpc/receipts/receipts_generator.go
@@ -189,6 +189,10 @@ func (g *Generator) GetReceipts(ctx context.Context, cfg *chain.Config, tx kv.Te
 }
 
 func (g *Generator) GetReceiptsGasUsed(tx kv.TemporalTx, block *types.Block) (types.Receipts, error) {
+	if receipts, ok := g.receiptsCache.Get(block.Hash()); ok {
+		return receipts, nil
+	}
+
 	if block == nil || len(block.Transactions()) == 0 {
 		return types.Receipts{}, nil
 	}
@@ -201,12 +205,13 @@ func (g *Generator) GetReceiptsGasUsed(tx kv.TemporalTx, block *types.Block) (ty
 	receipts := make(types.Receipts, len(block.Transactions()))
 
 	var prevCumGasUsed uint64
-	currentTxNum := startTxNum + 2
+	currentTxNum := startTxNum + 1
 	for i := range block.Transactions() {
 		receipt := &types.Receipt{}
-		cumGasUsed, _, _, err := rawtemporaldb.ReceiptAsOf(tx, currentTxNum)
+		cumGasUsed, _, _, err := rawtemporaldb.ReceiptAsOf(tx, currentTxNum+1)
 		if err != nil {
-			return nil, fmt.Errorf("get receipt for tx %d: %w", currentTxNum, err)
+			return nil, fmt.Errorf("get receipt at tx %d (block %d, index %d): %w",
+				currentTxNum, block.NumberU64(), i, err)
 		}
 
 		receipt.GasUsed = cumGasUsed - prevCumGasUsed

--- a/turbo/jsonrpc/receipts/receipts_generator.go
+++ b/turbo/jsonrpc/receipts/receipts_generator.go
@@ -201,11 +201,7 @@ func (g *Generator) GetReceiptsGasUsed(tx kv.TemporalTx, block *types.Block) (ty
 	txCount := len(block.Transactions())
 	receipts := make(types.Receipts, txCount)
 
-	prevCumGasUsed, _, _, err := rawtemporaldb.ReceiptAsOf(tx, startTxNum-2)
-	if err != nil {
-		return nil, fmt.Errorf("get base receipt: %w", err)
-	}
-
+	var prevCumGasUsed uint64
 	currentTxNum := startTxNum + 1
 	for i := 0; i < txCount; i++ {
 		receipt := &types.Receipt{}


### PR DESCRIPTION
Currently, a significant amount of time is spent on re-executing transactions. However, in reality, only the gasused by the transaction is needed, which can be obtained through the ` kv.ReceiptDomain`
After this pr, time from 117s -> 119ms
![feehcpu](https://github.com/user-attachments/assets/945d39b8-a6f1-4be7-b5fc-b966298011eb)
