### PR TITLE
params/chainspecs: Add blob schedule to bsc and chapel

### DIFF
--- a/params/chainspecs/bsc.json
+++ b/params/chainspecs/bsc.json
@@ -36,6 +36,18 @@
   "pragueTime": 1742436600,
   "pascalTime": 1742436600,
   "lorentzTime": 9999999999,
+  "blobSchedule": {
+    "cancun": {
+      "target": 3,
+      "max": 6,
+      "baseFeeUpdateFraction": 3338477
+    },
+    "prague": {
+      "target": 3,
+      "max": 6,
+      "baseFeeUpdateFraction": 3338477
+    }
+  },
   "parlia": {
     "DBPath": "",
     "InMemory": false,

--- a/params/chainspecs/chapel.json
+++ b/params/chainspecs/chapel.json
@@ -36,6 +36,18 @@
   "pragueTime": 1740452880,
   "pascalTime": 1740452880,
   "lorentzTime": 9999999999,
+  "blobSchedule": {
+    "cancun": {
+      "target": 3,
+      "max": 6,
+      "baseFeeUpdateFraction": 3338477
+    },
+    "prague": {
+      "target": 3,
+      "max": 6,
+      "baseFeeUpdateFraction": 3338477
+    }
+  },
   "parlia": {
     "DBPath": "",
     "InMemory": false,

--- a/params/chainspecs/rialto.json
+++ b/params/chainspecs/rialto.json
@@ -38,6 +38,18 @@
   "pragueTime": 0,
   "pascalTime": 0,
   "lorentzTime": 9999999999,
+  "blobSchedule": {
+    "cancun": {
+      "target": 3,
+      "max": 6,
+      "baseFeeUpdateFraction": 3338477
+    },
+    "prague": {
+      "target": 3,
+      "max": 6,
+      "baseFeeUpdateFraction": 3338477
+    }
+  },
   "parlia": {
     "DBPath": "",
     "InMemory": false,


### PR DESCRIPTION
If blobSchedule is nil, it will use default `5007716` as baseFeeUpdateFraction after prague. 