### PR TITLE
util.go: change default DefaultSnapshotGitBranch to main

### DIFF
--- a/erigon-lib/chain/snapcfg/util.go
+++ b/erigon-lib/chain/snapcfg/util.go
@@ -40,7 +40,7 @@ import (
 )
 
 // TODO(yperbasis) move into params/version.go
-const DefaultSnapshotGitBranch = "release/3.0"
+const DefaultSnapshotGitBranch = "main"
 
 var snapshotGitBranch = dbg.EnvString("SNAPS_GIT_BRANCH", DefaultSnapshotGitBranch)
 


### PR DESCRIPTION
fix upstream issue, bsc-erigon-sanpshots use main branch as default. Fix #653 #650

