### PR TITLE
parlia.go: add check for distributeToValidator

### DIFF
--- a/cmd/state/exec3/state.go
+++ b/cmd/state/exec3/state.go
@@ -19,8 +19,9 @@ package exec3
 import (
 	"context"
 	"fmt"
-	"github.com/erigontech/erigon/consensus/misc"
 	"sync"
+
+	"github.com/erigontech/erigon/consensus/misc"
 
 	"github.com/erigontech/erigon/core/systemcontracts"
 

--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -1057,10 +1057,12 @@ func (p *Parlia) finalize(header *types.Header, ibs *state.IntraBlockState, txs 
 		}
 	}
 
-	finish, err = p.distributeToValidator(header.Coinbase, ibs, header, &txs, &receipts, &systemTxs, &header.GasUsed, mining, systemTxCall, &curIndex, &txIndex)
-	if err != nil || finish {
-		//log.Error("distributeIncoming", "block hash", header.Hash(), "error", err, "systemTxs", len(systemTxs))
-		return nil, nil, nil, err
+	if userTxs.Len() != 0 {
+		finish, err = p.distributeToValidator(header.Coinbase, ibs, header, &txs, &receipts, &systemTxs, &header.GasUsed, mining, systemTxCall, &curIndex, &txIndex)
+		if err != nil || finish {
+			//log.Error("distributeIncoming", "block hash", header.Hash(), "error", err, "systemTxs", len(systemTxs))
+			return nil, nil, nil, err
+		}
 	}
 
 	if p.chainConfig.IsPlato(header.Number.Uint64()) {

--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -971,18 +971,15 @@ func (p *Parlia) finalize(header *types.Header, ibs *state.IntraBlockState, txs 
 
 	curIndex := userTxs.Len()
 
-	// Get validator snapshot for the current state
 	number := header.Number.Uint64()
 	snap, err := p.snapshot(chain, number-1, header.ParentHash, nil, false /* verify */)
 	if err != nil {
 		return nil, nil, nil, err
 	}
 
-	// Get parent header for fork determination
 	parentHeader := chain.GetHeader(header.ParentHash, number-1)
 	var finish bool
 
-	// Setup deferred function to update finality data if needed
 	defer func() {
 		if txIndex == len(txs)-1 && finish {
 			if fs := finality.GetFinalizationService(); fs != nil {


### PR DESCRIPTION
If there are no`useTxs`,but distributing the `FinalityReward`and updating the validator set with`updateValidatorSetV2`is necessary,the logic for updating`curIndex`would be flawed.Additionally,the`updateValidatorSetV2`transaction is expected to trigger the`distributeFinalityReward` function.