### PR TITLE
stage_headers.go: reduce skeleton request frequency

### DIFF
--- a/eth/stagedsync/stage_headers.go
+++ b/eth/stagedsync/stage_headers.go
@@ -237,7 +237,7 @@ Loop:
 		}
 
 		// Send skeleton request if required
-		if time.Since(lastSkeletonTime) > 1*time.Second && time.Since(time.UnixMilli(int64(cfg.hd.LastBlockTime))) > 1*time.Second {
+		if time.Since(lastSkeletonTime) > 1*time.Second && time.Since(time.UnixMilli(int64(cfg.hd.LastBlockTime))) > 3*time.Second {
 			req = cfg.hd.RequestSkeleton()
 			if req != nil {
 				peer, sentToPeer = cfg.headerReqSend(ctx, req)

--- a/eth/stagedsync/stage_headers.go
+++ b/eth/stagedsync/stage_headers.go
@@ -240,7 +240,7 @@ Loop:
 		}
 
 		// Send skeleton request if required
-		if time.Since(lastSkeletonTime) > 3*time.Second {
+		if time.Since(lastSkeletonTime) > 1*time.Second {
 			req = cfg.hd.RequestSkeleton()
 			if req != nil {
 				peer, sentToPeer = cfg.headerReqSend(ctx, req)

--- a/eth/stagedsync/stage_headers.go
+++ b/eth/stagedsync/stage_headers.go
@@ -237,16 +237,14 @@ Loop:
 		}
 
 		// Send skeleton request if required
-		if time.Since(lastSkeletonTime) > 1*time.Second {
+		if time.Since(lastSkeletonTime) > 1*time.Second && time.Since(time.UnixMilli(int64(cfg.hd.LastBlockTime))) > 1*time.Second {
 			req = cfg.hd.RequestSkeleton()
 			if req != nil {
-				if req.Number > prevProgress+1 {
-					peer, sentToPeer = cfg.headerReqSend(ctx, req)
-					if sentToPeer {
-						logger.Debug(fmt.Sprintf("[%s] Requested skeleton", logPrefix), "from", req.Number, "length", req.Length)
-						cfg.hd.UpdateStats(req, true /* skeleton */, peer)
-						lastSkeletonTime = time.Now()
-					}
+				peer, sentToPeer = cfg.headerReqSend(ctx, req)
+				if sentToPeer {
+					logger.Debug(fmt.Sprintf("[%s] Requested skeleton", logPrefix), "from", req.Number, "length", req.Length)
+					cfg.hd.UpdateStats(req, true /* skeleton */, peer)
+					lastSkeletonTime = time.Now()
 				}
 			}
 		}

--- a/eth/stagedsync/stage_headers.go
+++ b/eth/stagedsync/stage_headers.go
@@ -189,6 +189,9 @@ func HeadersPOW(s *StageState, u Unwinder, ctx context.Context, tx kv.RwTx, cfg 
 	prevProgress := startProgress
 	var wasProgress bool
 	var lastSkeletonTime time.Time
+	if !s.CurrentSyncCycle.IsInitialCycle {
+		lastSkeletonTime = time.Now()
+	}
 	var peer [64]byte
 	var sentToPeer bool
 Loop:
@@ -237,7 +240,7 @@ Loop:
 		}
 
 		// Send skeleton request if required
-		if time.Since(lastSkeletonTime) > 1*time.Second {
+		if time.Since(lastSkeletonTime) > 3*time.Second {
 			req = cfg.hd.RequestSkeleton()
 			if req != nil {
 				peer, sentToPeer = cfg.headerReqSend(ctx, req)

--- a/eth/stagedsync/stage_headers.go
+++ b/eth/stagedsync/stage_headers.go
@@ -190,7 +190,11 @@ func HeadersPOW(s *StageState, u Unwinder, ctx context.Context, tx kv.RwTx, cfg 
 	var wasProgress bool
 	var lastSkeletonTime time.Time
 	if !s.CurrentSyncCycle.IsInitialCycle {
-		lastSkeletonTime = time.Now()
+		header, err := cfg.blockReader.HeaderByHash(ctx, tx, hash)
+		if err != nil {
+			return err
+		}
+		lastSkeletonTime = time.UnixMilli(int64(header.MilliTimestamp()))
 	}
 	var peer [64]byte
 	var sentToPeer bool

--- a/turbo/stages/headerdownload/header_algos.go
+++ b/turbo/stages/headerdownload/header_algos.go
@@ -609,6 +609,7 @@ func (hd *HeaderDownload) InsertHeader(hf FeedHeaderFunc, terminalTotalDifficult
 			}
 			hd.highestInDb = link.blockHeight
 			hd.highestHashInDb = link.hash
+			hd.LastBlockTime = link.header.MilliTimestamp()
 		}
 		lastTime = link.header.Time
 		link.persisted = true

--- a/turbo/stages/headerdownload/header_data_struct.go
+++ b/turbo/stages/headerdownload/header_data_struct.go
@@ -315,6 +315,7 @@ type HeaderDownload struct {
 	pendingPayloadHash  common.Hash                 // Header whose status we still should send to PayloadStatusCh
 	unsettledHeadHeight uint64                      // Height of unsettledForkChoice.headBlockHash
 	badPoSHeaders       map[common.Hash]common.Hash // Invalid Tip -> Last Valid Ancestor
+	LastBlockTime       uint64
 	logger              log.Logger
 }
 


### PR DESCRIPTION
We should reduce the frequency of requesting skeletons when the node is at the chain tip.
<img width="1271" alt="image" src="https://github.com/user-attachments/assets/ef73fe14-cb7c-4808-8fbc-ba9c2631e646" />
