### PR TITLE
block_reader.go: fix panic

### DIFF
--- a/turbo/snapshotsync/freezeblocks/block_reader.go
+++ b/turbo/snapshotsync/freezeblocks/block_reader.go
@@ -753,6 +753,9 @@ func (r *BlockReader) BodyWithTransactions(ctx context.Context, tx kv.Getter, ha
 
 func (r *BlockReader) BodyRlp(ctx context.Context, tx kv.Getter, hash common.Hash, blockHeight uint64) (bodyRlp rlp.RawValue, err error) {
 	body, err := r.BodyWithTransactions(ctx, tx, hash, blockHeight)
+	if body == nil {
+		return nil, err
+	}
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fix handle message panic
`
[DBUG] [05-20|02:45:30.567] Handling incoming message                stream=RecvUploadMessage err="runtime error: invalid memory address or nil pointer dereference, msgID=GET_BLOCK_BODIES_66, trace: [sentry_multi_client.go:648 panic.go:770 panic.go:261 signal_unix.go:881 block_reader.go:762 handlers.go:152 sentry_multi_client.go:558 sentry_multi_client.go:682 sentry_multi_client.go:651 loop.go:126 asm_amd64.s:1695]"
`