### PR TITLE
config3.go: reduce MaxReorgDepthV3 to have more aggressive prune

### DIFF
--- a/erigon-lib/config3/config3.go
+++ b/erigon-lib/config3/config3.go
@@ -26,6 +26,6 @@ const StepsInFrozenFile = 64
 
 const EnableHistoryV4InTest = true
 
-const MaxReorgDepthV3 = 512
+const MaxReorgDepthV3 = 8
 
 const DefaultPruneDistance = 100_000


### PR DESCRIPTION
During live sync, the table ChangeSet size tends to grow（more than 100GB） because there isn't sufficient time to pruning, which negatively impacts performance and causes the db size to increase significantly. However, in BSC, we experience infrequent reorganizations (< 2block) due to fast-finality consensus. Therefore, we've reduced MaxReorgDepthV3 to 8 to enable more aggressive pruning and maintain optimal database performance


<img width="1033" alt="image" src="https://github.com/user-attachments/assets/fc3def36-080f-4773-b043-5f14c4937d97" />

