### PR TITLE
bsc_snapshots.go: close rotx before long (compressing/indexing) opera…

### DIFF
--- a/turbo/snapshotsync/freezeblocks/bsc_snapshots.go
+++ b/turbo/snapshotsync/freezeblocks/bsc_snapshots.go
@@ -197,6 +197,7 @@ func dumpBlobsRange(ctx context.Context, blockFrom, blockTo uint64, tmpDir, snap
 		}
 
 	}
+	tx.Rollback()
 	if err := sn.Compress(); err != nil {
 		return fmt.Errorf("compress: %w", err)
 	}


### PR DESCRIPTION
Find such logs for bsc-erigon,  close rotx before long (compressing/indexing) opera…
`[INFO] [06-16|07:30:48.424] [dbg.db.chaindata] long living resources list="1418(28m46.577758177s): [kv_mdbx.go:593 kv_temporal.go:82 kv_temporal.go:102 bsc_snapshots.go:159 bsc_snapshots.go:220 bsc_snapshots.go:63 block_snapshots.go:471 block_snapshots.go:415 asm_amd64.s:1700]`"
