### PR TITLE
block_snapshots.go: update compressCfg

### DIFF
--- a/turbo/snapshotsync/freezeblocks/block_snapshots.go
+++ b/turbo/snapshotsync/freezeblocks/block_snapshots.go
@@ -588,7 +588,7 @@ var BlockCompressCfg = seg.Cfg{
 	MinPatternScore: 1_000,
 	MinPatternLen:   8, // `5` - reducing ratio because producing too much prefixes
 	MaxPatternLen:   128,
-	SamplingFactor:  1,         // `4` - adding to save my time
+	SamplingFactor:  1,         // `4` - to save time, '1' - to save disk space
 	MaxDictPatterns: 64 * 1024, // the lower RAM used by huffman tree (arrays)
 
 	DictReducerSoftLimit: 2_000_000,


### PR DESCRIPTION
It will spend 2x time but save 10% storage
