### PR TITLE
header_algos.go: fix goroutine race

### DIFF
--- a/turbo/stages/headerdownload/header_algos.go
+++ b/turbo/stages/headerdownload/header_algos.go
@@ -24,7 +24,6 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"github.com/erigontech/erigon-lib/chain"
 	"io"
 	"math/big"
 	"slices"
@@ -33,6 +32,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/erigontech/erigon-lib/chain"
 	"github.com/erigontech/erigon-lib/common/dbg"
 	"github.com/erigontech/erigon-lib/common/metrics"
 	"github.com/erigontech/erigon-lib/kv/dbutils"
@@ -512,7 +512,7 @@ func (hd *HeaderDownload) RequestSkeleton() *HeaderRequest {
 	defer hd.lock.RUnlock()
 
 	var stride uint64
-	if hd.InitialCycle() || time.Since(time.UnixMilli(int64(hd.LastBlockTime))) > 200*time.Second {
+	if hd.initialCycle || time.Since(time.UnixMilli(int64(hd.LastBlockTime))) > 200*time.Second {
 		stride = uint64(hd.loopBlockLimit / 192)
 	}
 	var length uint64 = 192


### PR DESCRIPTION
```
#       0x4a95a4        sync.runtime_SemacquireRWMutexR+0x24                                                            runtime/sema.go:100
#       0x21f9a29       sync.(*RWMutex).RLock+0x49                                                                      sync/rwmutex.go:74
#       0x21f9a03       github.com/erigontech/erigon/turbo/stages/headerdownload.(*HeaderDownload).InitialCycle+0x23    github.com/erigontech/erigon/turbo/stages/headerdownload/header_algos.go:1268
#       0x21f297e       github.com/erigontech/erigon/turbo/stages/headerdownload.(*HeaderDownload).RequestSkeleton+0x7e github.com/erigontech/erigon/turbo/stages/headerdownload/header_algos.go:515
#       0x228eacc       github.com/erigontech/erigon/eth/stagedsync.HeadersPOW+0xf0c                                    github.com/erigontech/erigon/eth/stagedsync/stage_headers.go:241
#       0x228d964       github.com/erigontech/erigon/eth/stagedsync.SpawnStageHeaders+0x244                             github.com/erigontech/erigon/eth/stagedsync/stage_headers.go:124
#       0x2272b68       github.com/erigontech/erigon/eth/stagedsync.DefaultStages.func4+0xc8                            github.com/erigontech/erigon/eth/stagedsync/default_stages.go:64
#       0x22c3822       github.com/erigontech/erigon/eth/stagedsync.(*Sync).runStage+0x182                              github.com/erigontech/erigon/eth/stagedsync/sync.go:528
#       0x22c27ec       github.com/erigontech/erigon/eth/stagedsync.(*Sync).Run+0x2cc                                   github.com/erigontech/erigon/eth/stagedsync/sync.go:412
#       0x26ae04f       github.com/erigontech/erigon/turbo/stages.StageLoopIteration+0x46f                              github.com/erigontech/erigon/turbo/stages/stageloop.go:253
#       0x26acff2       github.com/erigontech/erigon/turbo/stages.StageLoop+0x2f2                                       github.com/erigontech/erigon/turbo/stages/stageloop.go:103
```