### PR TITLE
bsc_snapshots.go: fix bsc snapshots

### DIFF
--- a/eth/stagedsync/stage_bodies.go
+++ b/eth/stagedsync/stage_bodies.go
@@ -244,9 +244,8 @@ func BodiesForward(s *StageState, u Unwinder, ctx context.Context, tx kv.RwTx, c
 
 				if cfg.chanConfig.Parlia != nil && cfg.chanConfig.IsCancun(headerNumber, header.Time) {
 					if err = core.IsDataAvailable(cr, header, rawBody, cfg.bd.LatestBlockTime); err != nil {
-						cfg.bd.ClearBodyCache()
-						logger.Error("blob missed", "err", err)
-						return true, nil
+						logger.Debug("blob data temporarily unavailable, will retry", "number", blockHeight, "hash", header.Hash().String(), "err", err)
+						return false, nil
 					}
 				}
 

--- a/eth/stagedsync/stage_bodies.go
+++ b/eth/stagedsync/stage_bodies.go
@@ -244,7 +244,9 @@ func BodiesForward(s *StageState, u Unwinder, ctx context.Context, tx kv.RwTx, c
 
 				if cfg.chanConfig.Parlia != nil && cfg.chanConfig.IsCancun(headerNumber, header.Time) {
 					if err = core.IsDataAvailable(cr, header, rawBody, cfg.bd.LatestBlockTime); err != nil {
-						return false, err
+						cfg.bd.ClearBodyCache()
+						logger.Error("blob missed", "err", err)
+						return true, nil
 					}
 				}
 

--- a/eth/stagedsync/stage_snapshots.go
+++ b/eth/stagedsync/stage_snapshots.go
@@ -80,7 +80,7 @@ const (
 		a situation when we need to read indexes and we choose to read them from either a corrupt index or an incomplete index.
 		so we need to extend the threshold to > max_merge_segment_size.
 	*/
-	pruneMarkerSafeThreshold = snaptype.Erigon2MergeLimit * 1.5 // 1.5x the merge limit
+	pruneMarkerSafeThreshold = snaptype.Erigon2OldMergeLimit // 1.5x the merge limit
 )
 
 type SnapshotsCfg struct {

--- a/turbo/snapshotsync/freezeblocks/block_snapshots.go
+++ b/turbo/snapshotsync/freezeblocks/block_snapshots.go
@@ -520,12 +520,6 @@ func (br *BlockRetire) RemoveOverlaps() error {
 		}
 	}
 
-	if br.chainConfig.Parlia != nil {
-		if err := br.bscSnapshots().RoSnapshots.RemoveOverlaps(); err != nil {
-			return err
-		}
-	}
-
 	return nil
 }
 

--- a/turbo/snapshotsync/freezeblocks/bsc_snapshots.go
+++ b/turbo/snapshotsync/freezeblocks/bsc_snapshots.go
@@ -73,10 +73,10 @@ func (br *BlockRetire) retireBscBlocks(ctx context.Context, minBlockNum uint64, 
 				break
 			}
 			to := chooseSegmentEnd(i, blockTo, snap.Enum(), br.chainConfig)
-			logger.Log(lvl, "Dumping blobs sidecars", "from", i, "to", to)
+			logger.Log(lvl, "[bsc snapshots] Dumping blobs sidecars", "from", i, "to", to)
 			blocksRetired = true
 			if err := DumpBlobs(ctx, i, to, br.chainConfig, tmpDir, snapshots.Dir(), db, workers, lvl, blockReader, br.bs, logger); err != nil {
-				return blocksRetired, fmt.Errorf("DumpBlobs: %d-%d: %w", i, to, err)
+				return blocksRetired, fmt.Errorf("[bsc snapshots] DumpBlobs: %d-%d: %w", i, to, err)
 			}
 			logger.Log(lvl, "[bsc snapshots] Segment dumped", "i", i, "to", to)
 			totalSegments++
@@ -236,7 +236,7 @@ func dumpBlobsRange(ctx context.Context, blockFrom, blockTo uint64, tmpDir, snap
 
 		processedBlocks++
 		if blockNum%20_000 == 0 {
-			logger.Log(lvl, "Dumping bsc blobs", "progress", blockNum)
+			logger.Log(lvl, "[bsc snapshots] Dumping bsc blobs", "progress", blockNum)
 		}
 
 		return true, nil
@@ -271,13 +271,13 @@ func dumpBlobsRange(ctx context.Context, blockFrom, blockTo uint64, tmpDir, snap
 
 func DumpBlobs(ctx context.Context, blockFrom, blockTo uint64, chainConfig *chain.Config, tmpDir, snapDir string, chainDB kv.RoDB, workers int, lvl log.Lvl, blockReader services.FullBlockReader, blobStore services.BlobStorage, logger log.Logger) error {
 	startTime := time.Now()
-	logger.Log(lvl, "Dumping blobs sidecars", "from", blockFrom, "to", blockTo)
+	logger.Log(lvl, "[bsc snapshots] Dumping blobs sidecars", "from", blockFrom, "to", blockTo)
 
 	err := dumpBlobsRange(ctx, blockFrom, blockTo, tmpDir, snapDir, chainDB, blobStore, blockReader, chainConfig, workers, lvl, logger)
 
 	duration := time.Since(startTime)
 	blockCount := blockTo - blockFrom
-	logger.Log(lvl, "Dumping blobs sidecars completed", "from", blockFrom, "to", blockTo, "duration", duration, "blocks", blockCount, "blocks/sec", float64(blockCount)/duration.Seconds())
+	logger.Log(lvl, "[bsc snapshots] Dumping blobs sidecars completed", "from", blockFrom, "to", blockTo, "duration", duration, "blocks", blockCount, "blocks/sec", float64(blockCount)/duration.Seconds())
 
 	return err
 }

--- a/turbo/snapshotsync/freezeblocks/bsc_snapshots.go
+++ b/turbo/snapshotsync/freezeblocks/bsc_snapshots.go
@@ -271,8 +271,6 @@ func dumpBlobsRange(ctx context.Context, blockFrom, blockTo uint64, tmpDir, snap
 
 func DumpBlobs(ctx context.Context, blockFrom, blockTo uint64, chainConfig *chain.Config, tmpDir, snapDir string, chainDB kv.RoDB, workers int, lvl log.Lvl, blockReader services.FullBlockReader, blobStore services.BlobStorage, logger log.Logger) error {
 	startTime := time.Now()
-	logger.Log(lvl, "[bsc snapshots] Dumping blobs sidecars", "from", blockFrom, "to", blockTo)
-
 	err := dumpBlobsRange(ctx, blockFrom, blockTo, tmpDir, snapDir, chainDB, blobStore, blockReader, chainConfig, workers, lvl, logger)
 
 	duration := time.Since(startTime)

--- a/turbo/snapshotsync/freezeblocks/bsc_snapshots.go
+++ b/turbo/snapshotsync/freezeblocks/bsc_snapshots.go
@@ -65,8 +65,6 @@ func (br *BlockRetire) retireBscBlocks(ctx context.Context, minBlockNum uint64, 
 		blockFrom = minSnapBlockNum + 1
 		blockTo := maxBlockNum
 
-		blocksRetired = true
-
 		logger.Log(lvl, "[bsc snapshots] Retire BSC Blobs", "type", snap,
 			"blockFrom", blockFrom, "blockTo", blockTo)
 		segmentStartTime := time.Now()

--- a/turbo/stages/headerdownload/header_algos.go
+++ b/turbo/stages/headerdownload/header_algos.go
@@ -1030,7 +1030,7 @@ func (hi *HeaderInserter) FeedHeaderPoW(db kv.StatelessRwTx, headerReader servic
 		return nil, fmt.Errorf("[%s] failed to WriteTd: %w", hi.logPrefix, err)
 	}
 	if err = rawdb.WriteCanonicalHash(db, hash, blockHeight); err != nil {
-		return nil, fmt.Errorf("[%s] failed to save canonical hash: %w", err)
+		return nil, fmt.Errorf("[%s] failed to save canonical hash: %w", hi.logPrefix, err)
 	}
 	hi.prevHash = hash
 	return td, nil

--- a/turbo/stages/headerdownload/header_algos.go
+++ b/turbo/stages/headerdownload/header_algos.go
@@ -1029,6 +1029,9 @@ func (hi *HeaderInserter) FeedHeaderPoW(db kv.StatelessRwTx, headerReader servic
 	if err = rawdb.WriteTd(db, hash, blockHeight, td); err != nil {
 		return nil, fmt.Errorf("[%s] failed to WriteTd: %w", hi.logPrefix, err)
 	}
+	if err = rawdb.WriteCanonicalHash(db, hash, blockHeight); err != nil {
+		return nil, fmt.Errorf("[%s] failed to save canonical hash: %w", err)
+	}
 	hi.prevHash = hash
 	return td, nil
 }


### PR DESCRIPTION
Fix: #732 

1. stage_snapshots.go: adjust `pruneMarkerSafeThreshold` to keep the `HeaderCanonical` until blob snapshots generate
2. header_algos.go: add writeCanonicalHash when import header
3. bsc_snapshots.go: optimize bsc_snapshots
4. stage_bodies.go: clean cache when received empty blob. 