### PR TITLE
stage_execute.go: fix unwind issues

### DIFF
--- a/erigon-lib/config3/config3.go
+++ b/erigon-lib/config3/config3.go
@@ -26,6 +26,6 @@ const StepsInFrozenFile = 64
 
 const EnableHistoryV4InTest = true
 
-const MaxReorgDepthV3 = 8
+const MaxReorgDepthV3 = 32
 
 const DefaultPruneDistance = 100_000


### PR DESCRIPTION
1. in chapel, the chain may unwind more than 100 block, so it need bigger in chapel. fix #745 