### PR TITLE
exec3.go: decrease changesetSafeRange

### DIFF
--- a/erigon-lib/config3/config3.go
+++ b/erigon-lib/config3/config3.go
@@ -26,6 +26,6 @@ const StepsInFrozenFile = 64
 
 const EnableHistoryV4InTest = true
 
-const MaxReorgDepthV3 = 32
+const MaxReorgDepthV3 = 8
 
 const DefaultPruneDistance = 100_000

--- a/eth/stagedsync/exec3.go
+++ b/eth/stagedsync/exec3.go
@@ -64,7 +64,7 @@ var (
 )
 
 const (
-	changesetSafeRange     = 32   // Safety net for long-sync, keep last 32 changesets
+	changesetSafeRange     = 8    // Safety net for long-sync, keep last 8 changesets
 	maxUnwindJumpAllowance = 1000 // Maximum number of blocks we are allowed to unwind
 )
 

--- a/eth/stagedsync/stage_execute.go
+++ b/eth/stagedsync/stage_execute.go
@@ -337,10 +337,10 @@ func PruneExecutionStage(s *PruneState, tx kv.RwTx, cfg ExecuteBlockCfg, ctx con
 	// because on slow disks - prune is slower. but for now - let's tune for nvme first, and add `tx.SpaceDirty()` check later https://github.com/erigontech/erigon/issues/11635
 	quickPruneTimeout := 250 * time.Millisecond
 
-	var maxReorgDepth uint64
+	maxReorgDepth := uint64(config3.MaxReorgDepthV3)
 	if cfg.chainConfig.ChainName == networkname.Chapel {
 		// Chapel may have bigger unwind block
-		maxReorgDepth = config3.MaxReorgDepthV3 * 16
+		maxReorgDepth = maxReorgDepth * 16
 	}
 
 	if s.ForwardProgress > maxReorgDepth && !cfg.syncCfg.AlwaysGenerateChangesets {


### PR DESCRIPTION
```
Table                       Branch     Leaf Overflow    Entries Total(MB)    Ovfl%    Depth
-------------------------------------------------------------------------------------
   open-MADV_DONTNEED 16928767..16928768
   readahead OFF 0..16928768
                                 1        3       94         97     0.38    95.9%        2
BlockTransaction               350    77559    24228     715227   398.97    23.7%        4
ChangeSets3                   2385   164305 10449963   10482482 41471.30    98.4%        4
CodeVals                         1       84      649       1605     2.87    88.4%        2
Config                           0        1     1067          2     4.17    99.9%        1
Header                          19     1288        5       5152     5.12     0.4%        3
TxSender                         4      128     5090       5150    20.40    97.5%        3
```
Users don't have enough time to prune changeset3, so decrease the `changesetSafeRange` to keep less data. 