### PR TITLE
Fix GetPruneMarkerSafeThreshold

### DIFF
--- a/eth/rawdbreset/reset_stages.go
+++ b/eth/rawdbreset/reset_stages.go
@@ -397,13 +397,16 @@ const (
 )
 
 func GetPruneMarkerSafeThreshold(blockReader services.FullBlockReader) uint64 {
-	snapProgress := min(blockReader.FrozenBorBlocks(false), blockReader.FrozenBlocks())
-	if blockReader.BorSnapshots() == nil {
-		snapProgress = blockReader.FrozenBlocks()
+	snapProgress := blockReader.FrozenBlocks()
+
+	if blockReader.BorSnapshots() != nil {
+		snapProgress = min(snapProgress, blockReader.FrozenBorBlocks(false))
 	}
+
 	if blockReader.BscSnapshots() != nil {
-		snapProgress = blockReader.FrozenBscBlobs()
+		snapProgress = min(snapProgress, blockReader.FrozenBscBlobs())
 	}
+
 	if snapProgress < pruneMarkerSafeThreshold {
 		return 0
 	}

--- a/turbo/snapshotsync/freezeblocks/bsc_snapshots.go
+++ b/turbo/snapshotsync/freezeblocks/bsc_snapshots.go
@@ -57,7 +57,7 @@ func (br *BlockRetire) retireBscBlocks(ctx context.Context, minBlockNum uint64, 
 	for _, snap := range blockReader.BscSnapshots().Types() {
 		minSnapBlockNum := max(snapshots.DirtyBlocksAvailable(snap.Enum()), minBlockNum, minimumBlob)
 
-		if maxBlockNum <= minSnapBlockNum || maxBlockNum-minSnapBlockNum < snaptype.Erigon2OldMergeLimit+1024 {
+		if maxBlockNum <= minSnapBlockNum || maxBlockNum-minSnapBlockNum < snaptype.Erigon2OldMergeLimit {
 			continue
 		}
 


### PR DESCRIPTION
Should prune after all snapshots finished.  fix #767    
