### PR TITLE
rpcdaemon: fix panic

### DIFF
--- a/cmd/rpcdaemon/cli/config.go
+++ b/cmd/rpcdaemon/cli/config.go
@@ -422,8 +422,10 @@ func RemoteServices(ctx context.Context, cfg *httpcfg.HttpCfg, logger log.Logger
 
 		allSnapshots = freezeblocks.NewRoSnapshots(cfg.Snap, cfg.Dirs.Snap, logger)
 		allBorSnapshots = heimdall.NewRoSnapshots(cfg.Snap, cfg.Dirs.Snap, logger)
+		allBscSnapshots = freezeblocks.NewBscRoSnapshots(cfg.Snap, cfg.Dirs.Snap, logger)
 		allSnapshots.DownloadComplete()
 		allBorSnapshots.DownloadComplete()
+		allBscSnapshots.DownloadComplete()
 
 		heimdallStore = heimdall.NewSnapshotStore(heimdall.NewMdbxStore(logger, cfg.Dirs.DataDir, true, roTxLimit), allBorSnapshots)
 		bridgeStore = bridge.NewSnapshotStore(bridge.NewMdbxStore(cfg.Dirs.DataDir, logger, true, roTxLimit), allBorSnapshots, cc.Bor)


### PR DESCRIPTION
```
INFO[10-12|10:03:20.414] logging to file system                   log dir=/root/server/bsc-erigon-new/data/logs file prefix=rpcdaemon log level=info json=false
INFO[10-12|10:03:20.414] Enabling metrics export to prometheus    path=http://0.0.0.0:6061/debug/metrics/prometheus
WARN[10-12|10:03:20.414] Opening chain db                         path=/root/server/bsc-erigon-new/data/chaindata
INFO[10-12|10:03:20.416] [db] open                                label=chaindata sizeLimit=1TB pageSize=16KB
INFO[10-12|10:03:20.416] DB schemas compatible                    reader=7.0.0 database=7.0.0
INFO[10-12|10:03:20.452] adjusting receipt current version to v1.1 
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1ca1fda]

goroutine 1 [running]:
github.com/erigontech/erigon/cmd/rpcdaemon/cli.RemoteServices({0x309bfd8, 0xc0017370e0}, 0xc000e56a08, {0x30aefd0, 0xc000610d80}, 0xc0007012a0)
        github.com/erigontech/erigon/cmd/rpcdaemon/cli/config.go:452 +0x1c5a
main.main.func1(0xc00196d100?, {0x24da96d?, 0x4?, 0x24da971?})
        github.com/erigontech/erigon/cmd/rpcdaemon/main.go:43 +0xc5
github.com/spf13/cobra.(*Command).execute(0x4433a80, {0xc000050100, 0xe, 0xe})
        github.com/spf13/cobra@v1.10.1/command.go:1015 +0xa94
github.com/spf13/cobra.(*Command).ExecuteC(0x4433a80)
        github.com/spf13/cobra@v1.10.1/command.go:1148 +0x40c
github.com/spf13/cobra.(*Command).Execute(...)
        github.com/spf13/cobra@v1.10.1/command.go:1071
github.com/spf13/cobra.(*Command).ExecuteContext(...)
        github.com/spf13/cobra@v1.10.1/command.go:1064
main.main()
        github.com/erigontech/erigon/cmd/rpcdaemon/main.go:69 +0xf1
```